### PR TITLE
[Hotfix] 게시글 단계 수정이 가능하도록 변경 및 기타 ui 작업

### DIFF
--- a/src/features/board/components/Post/components/DetailModal/ProjectPostDetailModal.tsx
+++ b/src/features/board/components/Post/components/DetailModal/ProjectPostDetailModal.tsx
@@ -165,6 +165,12 @@ const PostDetailModal: React.FC<PostDetailModalProps> = ({
             console.log("프로젝트 정보:", postResponse.data.project);
             console.log("고객사:", postResponse.data.project?.clientCompany);
             console.log("개발사:", postResponse.data.project?.developerCompany);
+            console.log(
+              "우선순위 값:",
+              postResponse.data.priority,
+              "타입:",
+              typeof postResponse.data.priority
+            );
           }
 
           // 댓글 목록 가져오기
@@ -293,55 +299,142 @@ const PostDetailModal: React.FC<PostDetailModalProps> = ({
   };
 
   // 우선순위 텍스트 반환 함수
-  const getPriorityText = (priority: number) => {
-    switch (priority) {
-      case 1:
-        return "낮음";
-      case 2:
-        return "보통";
-      case 3:
-        return "높음";
-      case 4:
-        return "긴급";
-      default:
-        return "낮음";
+  const getPriorityText = (priority: any) => {
+    // 디버깅을 위한 로그 추가
+    console.log("우선순위 값:", priority, "타입:", typeof priority);
+
+    // 백엔드에서 오는 문자열 우선순위 처리
+    if (typeof priority === "string") {
+      switch (priority) {
+        case "LOW":
+          return "낮음";
+        case "MEDIUM":
+          return "보통";
+        case "HIGH":
+          return "높음";
+        case "URGENT":
+          return "긴급";
+        default:
+          console.warn(
+            "알 수 없는 우선순위 문자열:",
+            priority,
+            "기본값 '낮음' 사용"
+          );
+          return "낮음";
+      }
     }
+
+    // 숫자 우선순위 처리 (기존 호환성)
+    if (typeof priority === "number") {
+      switch (priority) {
+        case 1:
+          return "낮음";
+        case 2:
+          return "보통";
+        case 3:
+          return "높음";
+        case 4:
+          return "긴급";
+        default:
+          console.warn(
+            "알 수 없는 우선순위 숫자:",
+            priority,
+            "기본값 '낮음' 사용"
+          );
+          return "낮음";
+      }
+    }
+
+    console.warn(
+      "알 수 없는 우선순위 타입:",
+      typeof priority,
+      "값:",
+      priority,
+      "기본값 '낮음' 사용"
+    );
+    return "낮음";
   };
 
   // 우선순위별 스타일 반환 함수
-  const getPriorityStyle = (priority: number) => {
-    switch (priority) {
-      case 1:
-        return {
-          backgroundColor: "#dcfce7",
-          color: "#166534",
-          border: "1px solid #bbf7d0",
-        };
-      case 2:
-        return {
-          backgroundColor: "#fef3c7",
-          color: "#92400e",
-          border: "1px solid #fde68a",
-        };
-      case 3:
-        return {
-          backgroundColor: "#f3e8ff",
-          color: "#7c3aed",
-          border: "1px solid #e9d5ff",
-        };
-      case 4:
-        return {
-          backgroundColor: "#fee2e2",
-          color: "#dc2626",
-          border: "1px solid #fecaca",
-        };
-      default:
-        return {
-          backgroundColor: "#dcfce7",
-          color: "#166534",
-          border: "1px solid #bbf7d0",
-        };
+  const getPriorityStyle = (priority: any) => {
+    // 백엔드에서 오는 문자열 우선순위 처리
+    if (typeof priority === "string") {
+      switch (priority) {
+        case "LOW":
+          return {
+            backgroundColor: "#dcfce7",
+            color: "#166534",
+            border: "1px solid #bbf7d0",
+          };
+        case "MEDIUM":
+          return {
+            backgroundColor: "#fef3c7",
+            color: "#92400e",
+            border: "1px solid #fde68a",
+          };
+        case "HIGH":
+          return {
+            backgroundColor: "#f3e8ff",
+            color: "#7c3aed",
+            border: "1px solid #e9d5ff",
+          };
+        case "URGENT":
+          return {
+            backgroundColor: "#fee2e2",
+            color: "#dc2626",
+            border: "1px solid #fecaca",
+          };
+        default:
+          return {
+            backgroundColor: "#dcfce7",
+            color: "#166534",
+            border: "1px solid #bbf7d0",
+          };
+      }
     }
+
+    // 숫자 우선순위 처리 (기존 호환성)
+    if (typeof priority === "number") {
+      switch (priority) {
+        case 1:
+          return {
+            backgroundColor: "#dcfce7",
+            color: "#166534",
+            border: "1px solid #bbf7d0",
+          };
+        case 2:
+          return {
+            backgroundColor: "#fef3c7",
+            color: "#92400e",
+            border: "1px solid #fde68a",
+          };
+        case 3:
+          return {
+            backgroundColor: "#f3e8ff",
+            color: "#7c3aed",
+            border: "1px solid #e9d5ff",
+          };
+        case 4:
+          return {
+            backgroundColor: "#fee2e2",
+            color: "#dc2626",
+            border: "1px solid #fecaca",
+          };
+        default:
+          return {
+            backgroundColor: "#dcfce7",
+            color: "#166534",
+            border: "1px solid #bbf7d0",
+          };
+      }
+    }
+
+    // 기본 스타일
+    return {
+      backgroundColor: "#dcfce7",
+      color: "#166534",
+      border: "1px solid #bbf7d0",
+    };
   };
 
   const formatDate = (dateString: string) => {

--- a/src/features/board/components/Post/pages/PostListPage.tsx
+++ b/src/features/board/components/Post/pages/PostListPage.tsx
@@ -49,6 +49,7 @@ import {
 import PostDetailModal from "../components/DetailModal/ProjectPostDetailModal";
 import PostFormModal from "../components/FormModal/PostFormModal";
 import { useParams, useSearchParams } from "react-router-dom";
+import { showSuccessToast } from "@/utils/errorHandler";
 
 const formatDate = (dateString: string) => {
   let date;
@@ -181,6 +182,11 @@ export default function PostListPage() {
   );
   const [formModalPostId, setFormModalPostId] = useState<number | null>(null);
   const [formModalParentId, setFormModalParentId] = useState<number | null>(
+    null
+  );
+
+  // 게시글 수정 전 단계 정보 추적
+  const [editingPostStepId, setEditingPostStepId] = useState<number | null>(
     null
   );
 
@@ -330,6 +336,13 @@ export default function PostListPage() {
     setFormModalMode("edit");
     setFormModalPostId(postId);
     setFormModalParentId(null);
+
+    // 수정할 게시글의 현재 단계 정보 저장
+    const targetPost = posts.find((post) => post.postId === postId);
+    if (targetPost) {
+      setEditingPostStepId(targetPost.stepId || null);
+    }
+
     setIsFormModalOpen(true);
   };
 
@@ -349,6 +362,20 @@ export default function PostListPage() {
   const handleFormModalSuccess = () => {
     // 게시글 목록 새로고침
     fetchPosts();
+
+    // 단계 변경으로 인해 게시글이 사라졌을 수 있음을 안내
+    // (실제로는 백엔드에서 단계별로 게시글을 조회하므로,
+    // 단계가 변경된 게시글은 현재 단계 목록에서 사라짐)
+    if (editingPostStepId !== null && editingPostStepId !== Number(stepId)) {
+      showSuccessToast(
+        "게시글 수정 완료 - 단계가 변경되어 현재 목록에서 사라졌습니다."
+      );
+    } else {
+      showSuccessToast("게시글 수정 완료");
+    }
+
+    // 단계 정보 초기화
+    setEditingPostStepId(null);
   };
 
   const handlePostDelete = () => {

--- a/src/features/project-d/services/postService.ts
+++ b/src/features/project-d/services/postService.ts
@@ -287,7 +287,7 @@ export const updatePost = async (
       type: postData.type,
       status: postData.status,
       priority: postData.priority,
-      stepId: postData.stepId,
+      stepId: postData.stepId || 1, // stepId가 필수 필드이므로 기본값 1 사용
       ...(postData.fileIdsToDelete &&
         postData.fileIdsToDelete.length > 0 && {
           fileIdsToDelete: postData.fileIdsToDelete,

--- a/src/features/project-d/types/post.ts
+++ b/src/features/project-d/types/post.ts
@@ -146,7 +146,7 @@ export type PostUpdateRequest = {
   type?: PostType;
   status?: PostStatus;
   priority?: PostPriority;
-  stepId?: number;
+  stepId: number;
   fileIdsToDelete?: number[];
 };
 

--- a/src/features/project/components/Board/ProjectBoard.tsx
+++ b/src/features/project/components/Board/ProjectBoard.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/features/board/components/Post/styles/PostListPage.styled";
 import ProjectPostDetailModal from "@/features/board/components/Post/components/DetailModal/ProjectPostDetailModal";
 import PostFormModal from "@/features/board/components/Post/components/FormModal/PostFormModal";
+import { showSuccessToast } from "@/utils/errorHandler";
 
 interface ProjectBoardProps {
   projectId: number;
@@ -93,6 +94,11 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
   );
   const [formModalPostId, setFormModalPostId] = useState<number | null>(null);
   const [formModalParentId, setFormModalParentId] = useState<number | null>(
+    null
+  );
+
+  // 게시글 수정 전 단계 정보 추적
+  const [editingPostStepId, setEditingPostStepId] = useState<number | null>(
     null
   );
 
@@ -224,6 +230,13 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
     setFormModalMode("edit");
     setFormModalPostId(postId);
     setFormModalParentId(null);
+
+    // 수정할 게시글의 현재 단계 정보 저장
+    const targetPost = posts.find((post) => post.postId === postId);
+    if (targetPost) {
+      setEditingPostStepId(targetPost.projectStepId || null);
+    }
+
     setIsFormModalOpen(true);
   };
 
@@ -243,6 +256,18 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
   const handleFormModalSuccess = () => {
     // 게시글 목록 새로고침
     fetchPosts();
+
+    // 단계 변경으로 인해 게시글이 사라졌을 수 있음을 안내
+    if (editingPostStepId !== null && editingPostStepId !== selectedStepId) {
+      showSuccessToast(
+        "게시글 수정 완료 - 단계가 변경되어 현재 목록에서 사라졌습니다."
+      );
+    } else {
+      showSuccessToast("게시글 수정 완료");
+    }
+
+    // 단계 정보 초기화
+    setEditingPostStepId(null);
   };
 
   const handlePostDelete = (deletedPostId: number) => {
@@ -689,6 +714,7 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
         mode={formModalMode}
         postId={formModalPostId ?? undefined}
         parentId={formModalParentId ?? undefined}
+        stepId={selectedStepId}
         projectId={projectId}
         onSuccess={handleFormModalSuccess}
         colorTheme={{ main: "#fdb924", sub: "#f59e0b" }}


### PR DESCRIPTION
## 📌 개요
게시글 단계 수정이 가능하도록 변경

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- 게시글 수정 request DTO 변경사항 반영 및 단계 드롭다운 기본값 개선  
    - 백엔드 PostUpdateRequest DTO에 stepId 필드 추가에 맞춰 프론트엔드 수정
      - PostUpdateRequest 타입에서 stepId를 필수 필드로 변경
      - updatePost 함수에서 stepId가 undefined일 때 기본값 1 사용하도록 개선
    
    - 게시글 작성/수정 모달의 단계 드롭다운 기본값 개선
      - 게시글 작성 시: 사용자가 현재 위치한 단계(selectedStepId)를 기본으로 선택
      - 게시글 수정 시: 기존 게시글이 속한 단계를 기본으로 선택 (기존 유지)
      - ProjectBoard에서 PostFormModal 호출 시 selectedStepId prop 전달
    
    - 사용자 경험 개선
      - 특정 단계에서 게시글 작성 시 해당 단계가 드롭다운에서 기본 선택됨
      - 게시글 수정 시 현재 단계 ID가 요청에 자동 포함

## 🔍 관련 이슈
<!-- 예: Close #12 -->
- Close 
- See also #

## 🧪 테스트 결과
<!-- 테스트 방법 및 결과 요약 -->
<!-- - Postman으로 회원가입 API 정상 동작 확인 -->

## 👀 리뷰어에게 요청사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분 -->
<!-- - 이메일 형식 검증 로직에 문제 없는지 확인 부탁드립니다. -->

## 📎 기타 참고 사항
<!-- 추가적인 설명이나 참고 자료 (디자인 링크, API 문서 등) -->
<!-- - [API 문서](링크) -->
