### PR TITLE
[Style] 회원/업체 관리 페이지의 UI와 텍스트를 전체적으로 통일

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,32 +1,41 @@
-import { NavLink } from 'react-router-dom';
-import danmujiLogo from '../assets/danmuji-logo.png';
+import { NavLink } from "react-router-dom";
+import danmujiLogo from "../assets/danmuji-logo.png";
 
 const menu = [
-  { name: '대시보드', path: '/dashboard', icon: '/src/assets/dashboard.svg' },
-  { name: '회사 관리', path: '/company', icon: '/src/assets/company.svg' },
-  { name: '회원 관리', path: '/members', icon: '/src/assets/member.svg' },
-  { name: '프로젝트 관리', path: '/projects', icon: '/src/assets/project.svg' },
+  { name: "대시보드", path: "/dashboard", icon: "/src/assets/dashboard.svg" },
+  { name: "업체 관리", path: "/company", icon: "/src/assets/company.svg" },
+  { name: "회원 관리", path: "/members", icon: "/src/assets/member.svg" },
+  { name: "프로젝트 관리", path: "/projects", icon: "/src/assets/project.svg" },
 ];
 
 export default function Sidebar() {
   return (
     <aside className="w-56 bg-white shadow h-full flex flex-col">
       <div className="flex flex-col items-center gap-2 p-4 pt-6 pb-2">
-        <img src={danmujiLogo} alt="Danmuji Logo" style={{ height: '48px', width: 'auto', display: 'block' }} className="mb-2" />
+        <img
+          src={danmujiLogo}
+          alt="Danmuji Logo"
+          style={{ height: "48px", width: "auto", display: "block" }}
+          className="mb-2"
+        />
         <div className="flex flex-col items-center mt-4 mb-2">
-          <div className="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-lg font-bold text-gray-600 mb-1">김</div>
+          <div className="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-lg font-bold text-gray-600 mb-1">
+            김
+          </div>
           <div className="text-sm font-semibold text-gray-800">김관리자</div>
           <div className="text-xs text-gray-400">관리자</div>
         </div>
       </div>
       <nav className="flex-1 flex flex-col gap-2 p-4">
-        {menu.map(item => (
+        {menu.map((item) => (
           <NavLink
             key={item.path}
             to={item.path}
             className={({ isActive }) =>
               `flex items-center gap-2 px-4 py-2 rounded font-medium ${
-                isActive ? 'bg-[#FFC10A] text-white' : 'text-gray-700 hover:bg-gray-100'
+                isActive
+                  ? "bg-[#FFC10A] text-white"
+                  : "text-gray-700 hover:bg-gray-100"
               }`
             }
           >
@@ -37,4 +46,4 @@ export default function Sidebar() {
       </nav>
     </aside>
   );
-} 
+}

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -313,7 +313,7 @@ export default function ActivityLogDetailModal({
       case "USER":
         return "회원";
       case "COMPANY":
-        return "회사";
+        return "업체";
       case "PROJECT":
         return "프로젝트";
       case "PROJECT_STEP":
@@ -604,7 +604,7 @@ export default function ActivityLogDetailModal({
       bio: "소개",
 
       // 회사 관련 필드
-      companyName: "회사명",
+      companyName: "업체명",
       ceoName: "대표자명",
       bizNo: "사업자번호",
       address: "주소",

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -268,6 +268,23 @@ export default function ActivityLogDetailModal({
     }
   }, [isOpen, historyId]);
 
+  // ESC 키 이벤트 처리
+  useEffect(() => {
+    const handleEscapeKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && isOpen) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscapeKey);
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscapeKey);
+    };
+  }, [isOpen, onClose]);
+
   const fetchDetail = async () => {
     setLoading(true);
     setError(null);

--- a/src/features/admin/pages/ActivityLogPage.tsx
+++ b/src/features/admin/pages/ActivityLogPage.tsx
@@ -51,7 +51,7 @@ import {
   FiGrid,
 } from "react-icons/fi";
 import { FaProjectDiagram } from "react-icons/fa";
-import { RiUserSettingsLine } from "react-icons/ri";
+import { LuUserRoundCog } from "react-icons/lu";
 import UserSelectionModal from "../components/UserSelectionModal";
 import UserFilterButton from "../components/UserFilterButton";
 import ActivityLogDetailModal from "../components/ActivityLogDetailModal";
@@ -131,7 +131,7 @@ export default function ActivityLogPage() {
 
   const LOG_TYPE_OPTIONS = [
     { value: "ALL", label: "전체", icon: FiGrid, color: "#6b7280" },
-    { value: "USER", label: "회원", icon: FiUser, color: "#8b5cf6" },
+    { value: "USER", label: "회원", icon: FiUser, color: "#6366f1" },
     { value: "COMPANY", label: "업체", icon: FiHome, color: "#f59e0b" },
     {
       value: "PROJECT",
@@ -249,7 +249,7 @@ export default function ActivityLogPage() {
   const getTargetTypeIcon = (targetType: string) => {
     switch (targetType) {
       case "USER":
-        return <FiUser style={{ color: "#8b5cf6" }} />;
+        return <FiUser style={{ color: "#6366f1" }} />;
       case "COMPANY":
         return <FiHome style={{ color: "#f59e0b" }} />;
       case "PROJECT":
@@ -758,10 +758,7 @@ export default function ActivityLogPage() {
                     }}
                   >
                     {log.userRole === "ROLE_ADMIN" ? (
-                      <RiUserSettingsLine
-                        size={14}
-                        style={{ color: "#8b5cf6" }}
-                      />
+                      <LuUserRoundCog size={14} style={{ color: "#8b5cf6" }} />
                     ) : (
                       <FiUser size={14} style={{ color: "#6b7280" }} />
                     )}

--- a/src/features/admin/pages/ActivityLogPage.tsx
+++ b/src/features/admin/pages/ActivityLogPage.tsx
@@ -132,7 +132,7 @@ export default function ActivityLogPage() {
   const LOG_TYPE_OPTIONS = [
     { value: "ALL", label: "전체", icon: FiGrid, color: "#6b7280" },
     { value: "USER", label: "회원", icon: FiUser, color: "#8b5cf6" },
-    { value: "COMPANY", label: "회사", icon: FiHome, color: "#f59e0b" },
+    { value: "COMPANY", label: "업체", icon: FiHome, color: "#f59e0b" },
     {
       value: "PROJECT",
       label: "프로젝트",

--- a/src/features/admin/pages/ActivityLogPage.tsx
+++ b/src/features/admin/pages/ActivityLogPage.tsx
@@ -798,7 +798,7 @@ export default function ActivityLogPage() {
                       gap: "6px",
                     }}
                   >
-                    <FiCalendar size={14} style={{ color: "#6b7280" }} />
+                    <FiCalendar size={14} style={{ color: "#8b5cf6" }} />
                     <span style={{ fontSize: "14px", color: "#374151" }}>
                       {formatDateOnly(log.createdAt)}
                     </span>

--- a/src/features/admin/pages/DashboardPage.tsx
+++ b/src/features/admin/pages/DashboardPage.tsx
@@ -248,7 +248,7 @@ export default function DashboardPage() {
           </div>
         </RecentActivityCard>
 
-        {/* 회사 통계 카드 */}
+        {/* 업체 통계 카드 */}
         <RecentActivityCard
           style={{
             padding: "24px",
@@ -283,10 +283,10 @@ export default function DashboardPage() {
               <div
                 style={{ fontWeight: 600, fontSize: "16px", color: "#374151" }}
               >
-                총 회사 수
+                총 업체 수
               </div>
               <div style={{ fontSize: "14px", color: "#6b7280" }}>
-                전체 등록 회사
+                전체 등록 업체
               </div>
             </div>
           </div>
@@ -301,7 +301,7 @@ export default function DashboardPage() {
             {companyCount.toLocaleString()}
           </div>
           <div style={{ fontSize: "14px", color: "#6b7280" }}>
-            활성 회사:{" "}
+            활성 업체:{" "}
             <span style={{ color: "#10b981", fontWeight: 600 }}>1,222</span>
           </div>
         </RecentActivityCard>
@@ -637,7 +637,7 @@ export default function DashboardPage() {
           </RecentActivityList>
         </RecentActivityCard>
 
-        {/* 최근 등록된 회사 */}
+        {/* 최근 등록된 업체 */}
         <RecentActivityCard
           style={{
             border: "1px solid #e5e7eb",
@@ -657,7 +657,7 @@ export default function DashboardPage() {
             }}
           >
             <FaBuilding style={{ color: "#fdb924" }} />
-            최근 등록된 회사
+            최근 등록된 업체
           </RecentActivityTitle>
           <RecentActivityList>
             {recentCompanies.length > 0 ? (
@@ -680,7 +680,7 @@ export default function DashboardPage() {
             ) : (
               <RecentActivityItem style={{ padding: "8px 0" }}>
                 <span style={{ fontSize: "14px", color: "#6b7280" }}>
-                  회사가 없습니다.
+                  업체가 없습니다.
                 </span>
               </RecentActivityItem>
             )}

--- a/src/features/admin/services/activityLogService.ts
+++ b/src/features/admin/services/activityLogService.ts
@@ -128,7 +128,7 @@ export const transformHistoryToActivityLog = (
       case "USER":
         return "회원";
       case "COMPANY":
-        return "회사";
+        return "업체";
       case "PROJECT":
         return "프로젝트";
       case "STEP":

--- a/src/features/company/components/CompanyDetailModal/CompanyDetailModal.tsx
+++ b/src/features/company/components/CompanyDetailModal/CompanyDetailModal.tsx
@@ -90,7 +90,7 @@ const CompanyDetailModal: React.FC<CompanyDetailModalProps> = ({
         <Section>
           <SectionTitle>
             <FiFileText size={16} />
-            회사 소개
+            업체 소개
           </SectionTitle>
           <DetailItem>
             <DetailValue>{company.bio || "N/A"}</DetailValue>

--- a/src/features/company/components/CompanyFilterBar.tsx
+++ b/src/features/company/components/CompanyFilterBar.tsx
@@ -1,9 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import {
-  FiPlus,
-  FiChevronDown,
-  FiArrowUp,
-} from "react-icons/fi";
+import { FiPlus, FiChevronDown, FiArrowUp } from "react-icons/fi";
 import {
   FilterBar,
   FilterGroup,
@@ -143,10 +139,10 @@ const CompanyFilterBar: React.FC<CompanyFilterBarProps> = ({
           </div>
         </FilterGroup>
         <FilterGroup style={{ marginBottom: 0 }}>
-          <FilterLabel>회사명 검색</FilterLabel>
+          <FilterLabel>업체명 검색</FilterLabel>
           <SearchInput
             type="text"
-            placeholder="회사명을 입력하세요"
+            placeholder="업체명을 입력하세요"
             value={filters.keyword}
             onChange={(e) => onInputChange("keyword", e.target.value)}
           />
@@ -155,7 +151,8 @@ const CompanyFilterBar: React.FC<CompanyFilterBarProps> = ({
       <div style={{ display: "flex", gap: "10px", alignItems: "flex-end" }}>
         {onRegisterClick && (
           <NewButton onClick={onRegisterClick}>
-            <FiPlus />새 회사 등록
+            <FiPlus />
+            업체 등록
           </NewButton>
         )}
       </div>

--- a/src/features/company/components/CompanyRegisterModal/CompanyRegisterModal.tsx
+++ b/src/features/company/components/CompanyRegisterModal/CompanyRegisterModal.tsx
@@ -14,9 +14,8 @@ import {
 } from "react-icons/fi";
 import { useNotification } from "@/features/Notification/NotificationContext";
 import styled from "styled-components";
-import {
-  showSuccessToast,
-} from "@/utils/errorHandler";
+import { showSuccessToast } from "@/utils/errorHandler";
+import { IoMdClose } from "react-icons/io";
 
 const ModalOverlay = styled.div`
   position: fixed;
@@ -285,26 +284,59 @@ export default function CompanyRegisterModal({
     // 프론트 유효성 검사
     const newFieldErrors: FieldError[] = [];
 
-    if (!data.name?.trim()) {
-      newFieldErrors.push({ field: "name", value: data.name, reason: "회사명은 필수입니다." });
+    if (!data.name.trim()) {
+      newFieldErrors.push({
+        field: "name",
+        value: data.name,
+        reason: "업체명은 필수입니다.",
+      });
     }
     if (!data.ceoName?.trim()) {
-      newFieldErrors.push({ field: "ceoName", value: data.ceoName, reason: "대표자명은 필수입니다." });
+      newFieldErrors.push({
+        field: "ceoName",
+        value: data.ceoName,
+        reason: "대표자명은 필수입니다.",
+      });
     }
-    if (!data.bio?.trim()) {
-      newFieldErrors.push({ field: "bio", value: data.bio, reason: "회사 소개는 필수입니다." });
+    if (!data.bio.trim()) {
+      newFieldErrors.push({
+        field: "bio",
+        value: data.bio,
+        reason: "업체 소개는 필수입니다.",
+      });
     }
-    if (!/^\d{3}$/.test(data.reg1) || !/^\d{2}$/.test(data.reg2) || !/^\d{5}$/.test(data.reg3)) {
-      newFieldErrors.push({ field: "bizNo", value: bizNo, reason: "사업자등록번호 형식이 올바르지 않습니다." });
+    if (
+      !/^\d{3}$/.test(data.reg1) ||
+      !/^\d{2}$/.test(data.reg2) ||
+      !/^\d{5}$/.test(data.reg3)
+    ) {
+      newFieldErrors.push({
+        field: "bizNo",
+        value: bizNo,
+        reason: "사업자등록번호 형식이 올바르지 않습니다.",
+      });
     }
     if (!data.address?.trim()) {
-      newFieldErrors.push({ field: "address", value: data.address, reason: "주소는 필수입니다." });
+      newFieldErrors.push({
+        field: "address",
+        value: data.address,
+        reason: "주소는 필수입니다.",
+      });
     }
     if (!data.email?.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
-      newFieldErrors.push({ field: "email", value: data.email, reason: "올바른 이메일 형식이 아닙니다." });
+      newFieldErrors.push({
+        field: "email",
+        value: data.email,
+        reason: "올바른 이메일 형식이 아닙니다.",
+      });
     }
     if (!cleanedTel || !/^\d{9,11}$/.test(cleanedTel)) {
-      newFieldErrors.push({ field: "tel", value: data.tel, reason: "전화번호는 9~11자리의 숫자로 입력하세요. 예: 021231234, 01012345678" });
+      newFieldErrors.push({
+        field: "tel",
+        value: data.tel,
+        reason:
+          "전화번호는 9~11자리의 숫자로 입력하세요. 예: 021231234, 01012345678",
+      });
     }
 
     if (newFieldErrors.length > 0) {
@@ -325,23 +357,25 @@ export default function CompanyRegisterModal({
 
     try {
       await api.post("/api/companies", requestBody);
-      showSuccessToast("회사 등록이 완료되었습니다!");
+      showSuccessToast("업체 등록이 완료되었습니다!");
       onRegisterSuccess?.();
       handleClose();
     } catch (err: any) {
       console.error(err);
-  
+
       if (axios.isAxiosError(err) && err.response?.data) {
         const errorData = err.response.data as ErrorResponse;
-  
+
         // 🔽 필드 에러가 있으면 세팅
         if (errorData?.data?.errors) {
           setFieldErrors(errorData.data.errors);
         } else {
-          setErrorMessage(errorData.message || "회사 등록 중 오류가 발생했습니다.");
+          setErrorMessage(
+            errorData.message || "업체 등록 중 오류가 발생했습니다."
+          );
         }
       } else {
-        setErrorMessage("예상치 못한 오류가 발생했습니다.");
+        setErrorMessage("업체 등록 중 오류가 발생했습니다.");
       }
     }
   };
@@ -354,7 +388,7 @@ export default function CompanyRegisterModal({
         </CloseButton>
         <Title>
           <FiPlus size={20} />
-          회사 등록
+          업체 등록
         </Title>
 
         {/* 성공 / 에러 메시지 표시 */}
@@ -365,9 +399,9 @@ export default function CompanyRegisterModal({
           <FormGroup>
             <Label>
               <FiHome size={14} />
-              회사명
+              업체명
             </Label>
-            <Input name="name" placeholder="회사명을 입력하세요" />
+            <Input name="name" placeholder="업체명을 입력하세요" />
             {fieldErrors.find((e) => e.field === "name") && (
               <p style={{ color: "red", fontSize: "12px", marginTop: "4px" }}>
                 {fieldErrors.find((e) => e.field === "name")?.reason}
@@ -433,10 +467,7 @@ export default function CompanyRegisterModal({
               <FiUser size={14} />
               대표자명
             </Label>
-            <Input
-              name="ceoName"
-              placeholder="대표자명을 입력하세요"
-            />
+            <Input name="ceoName" placeholder="대표자명을 입력하세요" />
             {fieldErrors.find((e) => e.field === "ceoName") && (
               <p style={{ color: "red", fontSize: "12px", marginTop: "4px" }}>
                 {fieldErrors.find((e) => e.field === "ceoName")?.reason}
@@ -479,7 +510,7 @@ export default function CompanyRegisterModal({
           <FormGroup>
             <Label>
               <FiFileText size={14} />
-              회사 소개
+              업체 소개
             </Label>
             <TextArea
               name="bio"

--- a/src/features/company/pages/CompanyDetailPage.tsx
+++ b/src/features/company/pages/CompanyDetailPage.tsx
@@ -11,13 +11,7 @@ import {
 import CompanyEditModal from "../components/CompanyEditModal";
 import { type CompanyFormData } from "./CompanyPage";
 import { showErrorToast, showSuccessToast } from "@/utils/errorHandler";
-import {
-  FiUser,
-  FiBriefcase,
-  FiMapPin,
-  FiMail,
-  FiPhone,
-} from "react-icons/fi";
+import { FiUser, FiBriefcase, FiMapPin, FiMail, FiPhone } from "react-icons/fi";
 
 const PageContainer = styled.div`
   padding: 32px;
@@ -231,7 +225,7 @@ const CompanyDetailPage: React.FC = () => {
 
   const fetchCompanyDetail = useCallback(async () => {
     if (!id) {
-      setError("회사 ID가 누락되었습니다.");
+      setError("업체 ID가 누락되었습니다.");
       setLoading(false);
       return;
     }
@@ -240,12 +234,13 @@ const CompanyDetailPage: React.FC = () => {
       const response = await api.get(`/api/companies/${id}`);
       setCompany(response.data.data);
     } catch (err: unknown) {
-      let message = "회사 상세 정보를 가져오는 중 알 수 없는 오류가 발생했습니다.";
+      let message =
+        "업체 상세 정보를 가져오는 중 알 수 없는 오류가 발생했습니다.";
       if (err instanceof Error) {
         message = err.message;
       }
       setError(message);
-      console.error("회사 상세 정보 가져오기 실패:", err);
+      console.error("업체 상세 정보 가져오기 실패:", err);
     } finally {
       setLoading(false);
     }
@@ -264,13 +259,13 @@ const CompanyDetailPage: React.FC = () => {
 
   const handleDelete = async () => {
     if (!company) return;
-    if (window.confirm("정말 이 회사를 삭제하시겠습니까?")) {
+    if (window.confirm("정말 이 업체를 삭제하시겠습니까?")) {
       try {
         await api.delete(`/api/companies/${company.id}`);
-        showSuccessToast("회사가 성공적으로 삭제되었습니다.");
+        showSuccessToast("업체가 성공적으로 삭제되었습니다.");
         navigate("/company");
       } catch (error) {
-        showErrorToast("회사 삭제에 실패했습니다.");
+        showErrorToast("업체 삭제에 실패했습니다.");
         console.error("삭제 실패:", error);
       }
     }
@@ -279,7 +274,10 @@ const CompanyDetailPage: React.FC = () => {
   const handleUpdate = async (data: CompanyFormData) => {
     if (!editData) return;
     try {
-      const bizNoCombined = parseInt(`${data.reg1}${data.reg2}${data.reg3}`, 10);
+      const bizNoCombined = parseInt(
+        `${data.reg1}${data.reg2}${data.reg3}`,
+        10
+      );
       const companyUpdateData = {
         name: data.name,
         bizNo: bizNoCombined,
@@ -292,16 +290,16 @@ const CompanyDetailPage: React.FC = () => {
       await api.put(`/api/companies/${editData.id}`, companyUpdateData);
       setEditModalOpen(false);
       setEditData(null);
-      showSuccessToast("회사 정보가 성공적으로 수정되었습니다.");
+      showSuccessToast("업체 정보가 성공적으로 수정되었습니다.");
       fetchCompanyDetail();
     } catch {
-      showErrorToast("회사 정보 수정에 실패했습니다.");
+      showErrorToast("업체 정보 수정에 실패했습니다.");
     }
   };
 
   if (loading) return <PageContainer>로딩 중...</PageContainer>;
   if (error) return <PageContainer>오류: {error}</PageContainer>;
-  if (!company) return <PageContainer>회사를 찾을 수 없습니다.</PageContainer>;
+  if (!company) return <PageContainer>업체를 찾을 수 없습니다.</PageContainer>;
 
   return (
     <PageContainer>
@@ -317,19 +315,17 @@ const CompanyDetailPage: React.FC = () => {
         />
       )}
       <PageHeaderSection>
-        <PageTitle>회사 상세 정보</PageTitle>
-        <PageSubtitle>
-          해당 회사의 상세 정보를 한 눈에 확인하세요
-        </PageSubtitle>
+        <PageTitle>업체 상세 정보</PageTitle>
+        <PageSubtitle>해당 업체의 상세 정보를 한 눈에 확인하세요</PageSubtitle>
       </PageHeaderSection>
 
       <MainContentArea>
         <ProfileHeader>
-          <ProfileTitle>회사 프로필</ProfileTitle>
+          <ProfileTitle>업체 프로필</ProfileTitle>
           <ButtonGroup>
             <BackButton onClick={() => navigate(-1)}>뒤로가기</BackButton>
-            <DeleteButton onClick={handleDelete}>회사 삭제</DeleteButton>
-            <EditButton onClick={handleEdit}>회사 정보 수정</EditButton>
+            <DeleteButton onClick={handleDelete}>업체 삭제</DeleteButton>
+            <EditButton onClick={handleEdit}>업체 정보 수정</EditButton>
           </ButtonGroup>
         </ProfileHeader>
 
@@ -389,4 +385,4 @@ const CompanyDetailPage: React.FC = () => {
   );
 };
 
-export default CompanyDetailPage; 
+export default CompanyDetailPage;

--- a/src/features/company/pages/CompanyDetailPage.tsx
+++ b/src/features/company/pages/CompanyDetailPage.tsx
@@ -46,9 +46,10 @@ const PageTitle = styled.h1`
 `;
 
 const PageSubtitle = styled.p`
-  color: #6b7280;
-  font-size: 14px;
-  padding-left: 16px;
+  color: #bdbdbd;
+  font-size: 0.9rem;
+  margin-top: 6.6px;
+  margin-bottom: 18px;
 `;
 
 const MainContentArea = styled.div`
@@ -316,7 +317,9 @@ const CompanyDetailPage: React.FC = () => {
       )}
       <PageHeaderSection>
         <PageTitle>업체 상세 정보</PageTitle>
-        <PageSubtitle>해당 업체의 상세 정보를 한 눈에 확인하세요</PageSubtitle>
+        <PageSubtitle>
+          프로젝트 관리 시스템의 업체 정보를 한눈에 확인하세요
+        </PageSubtitle>
       </PageHeaderSection>
 
       <MainContentArea>

--- a/src/features/company/pages/CompanyPage.tsx
+++ b/src/features/company/pages/CompanyPage.tsx
@@ -590,15 +590,21 @@ export default function CompanyPage() {
                       >
                         <span style={{ fontSize: "14px", color: "#374151" }}>
                           {c.createdAt
-                            ? new Date(c.createdAt).toLocaleDateString("ko-KR")
+                            ? new Date(c.createdAt).toLocaleDateString(
+                                "ko-KR",
+                                {
+                                  year: "numeric",
+                                  month: "2-digit",
+                                  day: "2-digit",
+                                }
+                              )
                             : "N/A"}
                         </span>
                         {c.createdAt && (
-                          <span style={{ fontSize: "11px", color: "#9ca3af" }}>
+                          <span style={{ fontSize: "12px", color: "#6b7280" }}>
                             {new Date(c.createdAt).toLocaleTimeString("ko-KR", {
                               hour: "2-digit",
                               minute: "2-digit",
-                              hour12: true,
                             })}
                           </span>
                         )}

--- a/src/features/company/pages/CompanyPage.tsx
+++ b/src/features/company/pages/CompanyPage.tsx
@@ -7,6 +7,14 @@ import CompanyEditModal from "../components/CompanyEditModal";
 import CompanyFilterBar from "../components/CompanyFilterBar";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
+import {
+  FiHome,
+  FiUser,
+  FiMail,
+  FiPhone,
+  FiMapPin,
+  FiHash,
+} from "react-icons/fi";
 
 export interface Company {
   id: number;
@@ -69,63 +77,50 @@ const Subtitle = styled.p`
 `;
 
 const TableContainer = styled.div`
-  background: #fff;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
   overflow: hidden;
+  margin-bottom: 24px;
 `;
 
 const Table = styled.table`
   width: 100%;
-  font-size: 14px;
   border-collapse: collapse;
+  font-size: 14px;
 `;
 
 const TableHead = styled.thead`
   background-color: #f9fafb;
-  border-bottom: 1px solid #e5e7eb;
 `;
 
 const TableHeader = styled.th`
-  padding: 16px;
   text-align: left;
-  font-weight: 600;
+  padding: 12px 16px;
   color: #374151;
-  white-space: nowrap;
+  font-weight: 600;
   font-size: 13px;
+  border-bottom: 1px solid #e5e7eb;
 `;
 
 const TableBody = styled.tbody``;
 
 const TableRow = styled.tr`
-  border-bottom: 1px solid #f3f4f6;
-  transition: background-color 0.2s ease;
-
-  &:last-child {
-    border-bottom: none;
+  &:hover {
+    background-color: #fefdf4;
+    transition: background-color 0.2s ease;
   }
 
-  &:hover {
-    background-color: #f9fafb;
+  &:not(:last-child) {
+    border-bottom: 1px solid #f3f4f6;
   }
 `;
 
 const TableCell = styled.td`
-  padding: 16px;
-  text-align: left;
+  padding: 12px 16px;
   color: #374151;
   vertical-align: middle;
-  font-size: 14px;
-`;
-
-const CompanyNameCell = styled(TableCell)`
-  color: #374151;
-  font-weight: 500;
-  transition: color 0.2s ease;
-
-  &:hover {
-    color: #3b82f6;
-  }
+  text-align: left;
 `;
 
 const PaginationContainer = styled.div`
@@ -466,12 +461,12 @@ export default function CompanyPage() {
         <Table>
           <TableHead>
             <TableRow>
-              <TableHeader>업체명</TableHeader>
-              <TableHeader>사업자등록번호</TableHeader>
-              <TableHeader>주소</TableHeader>
-              <TableHeader>사업자 명</TableHeader>
-              <TableHeader>이메일</TableHeader>
-              <TableHeader>연락처</TableHeader>
+              <TableHeader style={{ width: "20%" }}>업체명</TableHeader>
+              <TableHeader style={{ width: "15%" }}>사업자등록번호</TableHeader>
+              <TableHeader style={{ width: "25%" }}>주소</TableHeader>
+              <TableHeader style={{ width: "12%" }}>사업자 명</TableHeader>
+              <TableHeader style={{ width: "15%" }}>이메일</TableHeader>
+              <TableHeader style={{ width: "13%" }}>연락처</TableHeader>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -503,12 +498,108 @@ export default function CompanyPage() {
                   key={c.id}
                   onClick={() => handleCompanyClick(c)}
                 >
-                  <CompanyNameCell>{c.name}</CompanyNameCell>
-                  <TableCell>{formatBizNo(c.bizNo.toString())}</TableCell>
-                  <TableCell>{c.address}</TableCell>
-                  <TableCell>{c.ceoName}</TableCell>
-                  <TableCell>{c.email}</TableCell>
-                  <TableCell>{formatTelNo(c.tel)}</TableCell>
+                  <TableCell>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "8px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      <FiHome size={14} style={{ color: "#f59e0b" }} />
+                      <span
+                        style={{
+                          fontSize: "14px",
+                          color: "#374151",
+                          fontWeight: "500",
+                        }}
+                      >
+                        {c.name}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "8px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      <FiHash size={14} style={{ color: "#6366f1" }} />
+                      <span style={{ fontSize: "14px", color: "#374151" }}>
+                        {formatBizNo(c.bizNo.toString())}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "8px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      <FiMapPin size={14} style={{ color: "#10b981" }} />
+                      <span style={{ fontSize: "14px", color: "#374151" }}>
+                        {c.address}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "8px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      <FiUser size={14} style={{ color: "#3b82f6" }} />
+                      <span
+                        style={{
+                          fontSize: "14px",
+                          color: "#374151",
+                          fontWeight: "500",
+                        }}
+                      >
+                        {c.ceoName}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "8px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      <FiMail size={14} style={{ color: "#8b5cf6" }} />
+                      <span style={{ fontSize: "14px", color: "#374151" }}>
+                        {c.email}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "8px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      <FiPhone size={14} style={{ color: "#f59e0b" }} />
+                      <span style={{ fontSize: "14px", color: "#374151" }}>
+                        {formatTelNo(c.tel)}
+                      </span>
+                    </div>
+                  </TableCell>
                 </ClickableTableRow>
               ))}
           </TableBody>

--- a/src/features/company/pages/CompanyPage.tsx
+++ b/src/features/company/pages/CompanyPage.tsx
@@ -14,6 +14,7 @@ import {
   FiPhone,
   FiMapPin,
   FiHash,
+  FiCalendar,
 } from "react-icons/fi";
 
 export interface Company {
@@ -25,6 +26,7 @@ export interface Company {
   email: string;
   bio: string;
   tel: string;
+  createdAt?: string;
 }
 
 export interface CompanyFormData {
@@ -461,12 +463,11 @@ export default function CompanyPage() {
         <Table>
           <TableHead>
             <TableRow>
-              <TableHeader style={{ width: "20%" }}>업체명</TableHeader>
-              <TableHeader style={{ width: "15%" }}>사업자등록번호</TableHeader>
-              <TableHeader style={{ width: "25%" }}>주소</TableHeader>
-              <TableHeader style={{ width: "12%" }}>사업자 명</TableHeader>
-              <TableHeader style={{ width: "15%" }}>이메일</TableHeader>
-              <TableHeader style={{ width: "13%" }}>연락처</TableHeader>
+              <TableHeader>업체명</TableHeader>
+              <TableHeader>사업자등록번호</TableHeader>
+              <TableHeader>대표자</TableHeader>
+              <TableHeader>연락처</TableHeader>
+              <TableHeader>생성일</TableHeader>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -543,21 +544,6 @@ export default function CompanyPage() {
                         cursor: "pointer",
                       }}
                     >
-                      <FiMapPin size={14} style={{ color: "#10b981" }} />
-                      <span style={{ fontSize: "14px", color: "#374151" }}>
-                        {c.address}
-                      </span>
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <div
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "8px",
-                        cursor: "pointer",
-                      }}
-                    >
                       <FiUser size={14} style={{ color: "#3b82f6" }} />
                       <span
                         style={{
@@ -579,9 +565,9 @@ export default function CompanyPage() {
                         cursor: "pointer",
                       }}
                     >
-                      <FiMail size={14} style={{ color: "#8b5cf6" }} />
+                      <FiPhone size={14} style={{ color: "#f59e0b" }} />
                       <span style={{ fontSize: "14px", color: "#374151" }}>
-                        {c.email}
+                        {formatTelNo(c.tel)}
                       </span>
                     </div>
                   </TableCell>
@@ -594,10 +580,29 @@ export default function CompanyPage() {
                         cursor: "pointer",
                       }}
                     >
-                      <FiPhone size={14} style={{ color: "#f59e0b" }} />
-                      <span style={{ fontSize: "14px", color: "#374151" }}>
-                        {formatTelNo(c.tel)}
-                      </span>
+                      <FiCalendar size={14} style={{ color: "#8b5cf6" }} />
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "4px",
+                        }}
+                      >
+                        <span style={{ fontSize: "14px", color: "#374151" }}>
+                          {c.createdAt
+                            ? new Date(c.createdAt).toLocaleDateString("ko-KR")
+                            : "N/A"}
+                        </span>
+                        {c.createdAt && (
+                          <span style={{ fontSize: "11px", color: "#9ca3af" }}>
+                            {new Date(c.createdAt).toLocaleTimeString("ko-KR", {
+                              hour: "2-digit",
+                              minute: "2-digit",
+                              hour12: true,
+                            })}
+                          </span>
+                        )}
+                      </div>
                     </div>
                   </TableCell>
                 </ClickableTableRow>

--- a/src/features/company/pages/CompanyPage.tsx
+++ b/src/features/company/pages/CompanyPage.tsx
@@ -122,7 +122,7 @@ const CompanyNameCell = styled(TableCell)`
   color: #374151;
   font-weight: 500;
   transition: color 0.2s ease;
-  
+
   &:hover {
     color: #3b82f6;
   }
@@ -335,17 +335,15 @@ export default function CompanyPage() {
     fetchCompanies();
   };
 
-  // 필터링된 회사 목록
+  // 필터링된 업체 목록
   const filteredCompanies = companies.filter((company) => {
     if (!filters.keyword) return true;
 
     const keyword = filters.keyword.toLowerCase();
-    return (
-      company.name.toLowerCase().includes(keyword)
-    );
+    return company.name.toLowerCase().includes(keyword);
   });
 
-  // 정렬된 회사 목록
+  // 정렬된 업체 목록
   const sortedCompanies = [...filteredCompanies].sort((a, b) => {
     switch (filters.sort) {
       case "name":
@@ -363,7 +361,7 @@ export default function CompanyPage() {
     if (!page) return "";
     const start = page.number * page.size + 1;
     const end = Math.min((page.number + 1) * page.size, page.totalElements);
-    return `총 ${page.totalElements}개의 회사 중 ${start}-${end}개 표시`;
+    return `총 ${page.totalElements}개의 업체 중 ${start}-${end}개 표시`;
   };
 
   const handleEdit = async (data: CompanyFormData) => {
@@ -410,7 +408,7 @@ export default function CompanyPage() {
       // 모달 닫기
       setEditModalOpen(false);
       setEditData(null);
-      notify("회사 정보가 성공적으로 수정되었습니다.");
+      notify("업체 정보가 성공적으로 수정되었습니다.");
       handleClose();
     } catch (err) {
       if (axios.isAxiosError(err)) {
@@ -419,11 +417,11 @@ export default function CompanyPage() {
           setFieldErrors(errorData.data.errors);
         } else {
           setError(
-            errorData?.message || "회사 수정 중 알 수 없는 오류가 발생했습니다."
+            errorData?.message || "업체 수정 중 알 수 없는 오류가 발생했습니다."
           );
         }
       } else {
-        setError("회사 수정 중 알 수 없는 오류가 발생했습니다.");
+        setError("업체 수정 중 알 수 없는 오류가 발생했습니다.");
       }
     }
   };
@@ -451,9 +449,9 @@ export default function CompanyPage() {
         />
       )}
       <HeaderSection>
-        <Title>회사 관리</Title>
+        <Title>업체 관리</Title>
         <Subtitle>
-          프로젝트 관리 시스템의 회사 정보를 한눈에 확인하세요
+          프로젝트 관리 시스템의 업체 정보를 한눈에 확인하세요
         </Subtitle>
       </HeaderSection>
 
@@ -468,7 +466,7 @@ export default function CompanyPage() {
         <Table>
           <TableHead>
             <TableRow>
-              <TableHeader>회사명</TableHeader>
+              <TableHeader>업체명</TableHeader>
               <TableHeader>사업자등록번호</TableHeader>
               <TableHeader>주소</TableHeader>
               <TableHeader>사업자 명</TableHeader>

--- a/src/features/project-d/pages/CreateProjectPage.tsx
+++ b/src/features/project-d/pages/CreateProjectPage.tsx
@@ -31,7 +31,7 @@ export default function ProjectCreatePage() {
   const [startDate, setStartDate] = useState<Date | null>(null);
   const [endDate, setEndDate] = useState<Date | null>(null);
 
-  // 회사 옵션을 react-select 형식으로 변환
+  // 업체 옵션을 react-select 형식으로 변환
   const companyToOption = (company: Company) => ({
     value: company.id,
     label: company.name,
@@ -293,11 +293,16 @@ export default function ProjectCreatePage() {
               setSelectedDevMembers([]);
               setDeveloperId("");
             }}
-            placeholder="회사 검색/선택"
+            placeholder="업체 검색/선택"
             isClearable
             inputId="dev-company"
             styles={{
               container: (base) => ({ ...base, width: "100%" }),
+              control: (base) => ({
+                ...base,
+                minHeight: "40px",
+                backgroundColor: "white",
+              }),
             }}
           />
         </S.Section>
@@ -383,7 +388,7 @@ export default function ProjectCreatePage() {
               setSelectedClientMembers([]);
               setClientId("");
             }}
-            placeholder="회사 검색/선택"
+            placeholder="업체 검색/선택"
             isClearable
             inputId="client-company"
             styles={{

--- a/src/features/project-d/pages/EditProjectPage.tsx
+++ b/src/features/project-d/pages/EditProjectPage.tsx
@@ -72,7 +72,7 @@ export default function ProjectEditPage() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
 
-  // 회사 옵션을 react-select 형식으로 변환
+  // 업체 옵션을 react-select 형식으로 변환
   const companyToOption = (company: Company) => ({
     value: company.id,
     label: company.name,
@@ -92,7 +92,7 @@ export default function ProjectEditPage() {
         : Array.isArray(payload.content)
         ? payload.content
         : [];
-      setCompanies(list); // 회사 목록 저장
+      setCompanies(list); // 업체 목록 저장
       return list.map(companyToOption);
     } catch (err) {
       return [];
@@ -111,13 +111,13 @@ export default function ProjectEditPage() {
         setStartDate(proj.startDate ? new Date(proj.startDate) : null);
         setEndDate(proj.endDate ? new Date(proj.endDate) : null);
 
-        // 회사 정보 설정
+        // 업체 정보 설정
         const devCompany = proj.developers[0]?.companyId;
         const clientCompany = proj.clients[0]?.companyId;
         setDevelopCompanyId(devCompany || "");
         setClientCompanyId(clientCompany || "");
 
-        // 회사 정보 로드
+        // 업체 정보 로드
         if (devCompany) {
           api
             .get(`/api/companies/${devCompany}`)
@@ -436,7 +436,7 @@ export default function ProjectEditPage() {
               setSelectedDevMembers([]); // 개발사 변경 시 멤버 초기화
               setDeveloperId(""); // 담당자도 초기화
             }}
-            placeholder="회사 검색/선택"
+            placeholder="업체 검색/선택"
             isClearable
             inputId="dev-company"
             styles={{
@@ -521,7 +521,7 @@ export default function ProjectEditPage() {
               setSelectedClientMembers([]); // 고객사 변경 시 멤버 초기화
               setClientId(""); // 담당자도 초기화
             }}
-            placeholder="회사 검색/선택"
+            placeholder="업체 검색/선택"
             isClearable
             inputId="client-company"
             styles={{

--- a/src/features/project/components/Board/ProjectBoard.tsx
+++ b/src/features/project/components/Board/ProjectBoard.tsx
@@ -52,7 +52,13 @@ import {
   FiGrid,
   FiPlus,
   FiTarget,
+  FiCalendar,
+  FiTag,
+  FiStar,
+  FiCheckCircle,
+  FiAlertCircle,
 } from "react-icons/fi";
+import { LuUserRoundCog } from "react-icons/lu";
 import { POST_PRIORITY_LABELS } from "../../types/Types";
 import ProjectPostDetailModal from "@/features/board/components/Post/components/DetailModal/ProjectPostDetailModal";
 import PostFormModal from "@/features/board/components/Post/components/FormModal/PostFormModal";
@@ -431,19 +437,12 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
     const timeStr = date.toLocaleTimeString("ko-KR", {
       hour: "2-digit",
       minute: "2-digit",
-      hour12: true,
     });
 
     return (
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-        }}
-      >
-        <div style={{ fontSize: "14px", color: "#6b7280" }}>{dateStr}</div>
-        <div style={{ fontSize: "13px", color: "#9ca3af" }}>{timeStr}</div>
+      <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+        <span style={{ fontSize: "14px", color: "#374151" }}>{dateStr}</span>
+        <span style={{ fontSize: "12px", color: "#6b7280" }}>{timeStr}</span>
       </div>
     );
   };
@@ -551,7 +550,10 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
             )}
           </Td>
           <Td>
-            <span>{post.authorName}</span>
+            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+              <FiUser size={14} style={{ color: "#3b82f6" }} />
+              <span>{post.authorName}</span>
+            </div>
           </Td>
           <Td>
             <TypeBadge type={post.type as "GENERAL" | "QUESTION"}>
@@ -564,7 +566,18 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
                 post.priority}
             </StatusBadge>
           </Td>
-          <Td>{formatDate(post.createdAt)}</Td>
+          <Td style={{ textAlign: "center" }}>
+            <div
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "12px",
+              }}
+            >
+              <FiCalendar size={14} style={{ color: "#8b5cf6" }} />
+              {formatDate(post.createdAt)}
+            </div>
+          </Td>
         </Tr>
       ));
     } else {
@@ -610,7 +623,12 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
               )}
             </Td>
             <Td>
-              <span>{parentPost.authorName}</span>
+              <div
+                style={{ display: "flex", alignItems: "center", gap: "8px" }}
+              >
+                <FiUser size={14} style={{ color: "#3b82f6" }} />
+                <span>{parentPost.authorName}</span>
+              </div>
             </Td>
             <Td>
               <TypeBadge type={parentPost.type as "GENERAL" | "QUESTION"}>
@@ -623,7 +641,18 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
                   parentPost.priority}
               </StatusBadge>
             </Td>
-            <Td>{formatDate(parentPost.createdAt)}</Td>
+            <Td style={{ textAlign: "center" }}>
+              <div
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "12px",
+                }}
+              >
+                <FiCalendar size={14} style={{ color: "#8b5cf6" }} />
+                {formatDate(parentPost.createdAt)}
+              </div>
+            </Td>
           </Tr>
         );
 
@@ -678,7 +707,12 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
                 )}
               </Td>
               <Td>
-                <span>{child.authorName}</span>
+                <div
+                  style={{ display: "flex", alignItems: "center", gap: "8px" }}
+                >
+                  <FiUser size={14} style={{ color: "#3b82f6" }} />
+                  <span>{child.authorName}</span>
+                </div>
               </Td>
               <Td>
                 <TypeBadge type={child.type as "GENERAL" | "QUESTION"}>
@@ -691,7 +725,18 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
                     child.priority}
                 </StatusBadge>
               </Td>
-              <Td>{formatDate(child.createdAt)}</Td>
+              <Td style={{ textAlign: "center" }}>
+                <div
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: "12px",
+                  }}
+                >
+                  <FiCalendar size={14} style={{ color: "#8b5cf6" }} />
+                  {formatDate(child.createdAt)}
+                </div>
+              </Td>
             </Tr>
           );
         });
@@ -742,7 +787,12 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
               )}
             </Td>
             <Td>
-              <span>{orphan.authorName}</span>
+              <div
+                style={{ display: "flex", alignItems: "center", gap: "8px" }}
+              >
+                <FiUser size={14} style={{ color: "#3b82f6" }} />
+                <span>{orphan.authorName}</span>
+              </div>
             </Td>
             <Td>
               <TypeBadge type={orphan.type as "GENERAL" | "QUESTION"}>
@@ -755,7 +805,18 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
                   orphan.priority}
               </StatusBadge>
             </Td>
-            <Td>{formatDate(orphan.createdAt)}</Td>
+            <Td style={{ textAlign: "center" }}>
+              <div
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "12px",
+                }}
+              >
+                <FiCalendar size={14} style={{ color: "#8b5cf6" }} />
+                {formatDate(orphan.createdAt)}
+              </div>
+            </Td>
           </Tr>
         );
       });
@@ -1094,12 +1155,12 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
       <Table>
         <Thead>
           <Tr>
-            <Th>제목</Th>
-            <Th></Th>
-            <Th>작성자</Th>
-            <Th>유형</Th>
-            <Th>우선순위</Th>
-            <Th>작성일</Th>
+            <Th style={{ width: "20%" }}>제목</Th>
+            <Th style={{ width: "5%" }}></Th>
+            <Th style={{ textAlign: "left", width: "5%" }}>작성자</Th>
+            <Th style={{ width: "5%" }}>유형</Th>
+            <Th style={{ width: "5%" }}>우선순위</Th>
+            <Th style={{ textAlign: "center", width: "10%" }}>작성일</Th>
           </Tr>
         </Thead>
         <Tbody>

--- a/src/features/project/components/ProjectCreateModal.tsx
+++ b/src/features/project/components/ProjectCreateModal.tsx
@@ -9,12 +9,22 @@ type Member = {
 
 type SelectedDevCompany = {
   company: { id: number; name: string };
-  members: { id: number; name: string; position: string; type: 'manager' | 'member' }[];
+  members: {
+    id: number;
+    name: string;
+    position: string;
+    type: "manager" | "member";
+  }[];
 };
 
 type SelectedClientCompany = {
   company: { id: number; name: string };
-  members: { id: number; name: string; position: string; type: 'manager' | 'member' }[];
+  members: {
+    id: number;
+    name: string;
+    position: string;
+    type: "manager" | "member";
+  }[];
 };
 
 interface ProjectCreateModalProps {
@@ -24,7 +34,11 @@ interface ProjectCreateModalProps {
 }
 
 // 프로젝트 등록 모달 컴포넌트
-export default function ProjectCreateModal({ open, onClose, fetchProjects }: ProjectCreateModalProps) {
+export default function ProjectCreateModal({
+  open,
+  onClose,
+  fetchProjects,
+}: ProjectCreateModalProps) {
   const initialForm = {
     name: "",
     description: "",
@@ -37,39 +51,69 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
   };
   const [form, setForm] = useState(initialForm);
   const [showDevModal, setShowDevModal] = useState(false);
-  const [selectedDevCompanies, setSelectedDevCompanies] = useState<SelectedDevCompany[]>([]);
-  const [selectedClientCompanies, setSelectedClientCompanies] = useState<SelectedClientCompany[]>([]);
+  const [selectedDevCompanies, setSelectedDevCompanies] = useState<
+    SelectedDevCompany[]
+  >([]);
+  const [selectedClientCompanies, setSelectedClientCompanies] = useState<
+    SelectedClientCompany[]
+  >([]);
   const [showClientModal, setShowClientModal] = useState(false);
-  const [editDevCompany, setEditDevCompany] = useState<{ id: number; name: string } | null>(null);
-  const [editDevMembers, setEditDevMembers] = useState<{ id: number; name: string; position: string; type: 'manager' | 'member' }[]>([]);
-  const [editClientCompany, setEditClientCompany] = useState<{ id: number; name: string } | null>(null);
-  const [editClientMembers, setEditClientMembers] = useState<{ id: number; name: string; position: string; type: 'manager' | 'member' }[]>([]);
+  const [editDevCompany, setEditDevCompany] = useState<{
+    id: number;
+    name: string;
+  } | null>(null);
+  const [editDevMembers, setEditDevMembers] = useState<
+    { id: number; name: string; position: string; type: "manager" | "member" }[]
+  >([]);
+  const [editClientCompany, setEditClientCompany] = useState<{
+    id: number;
+    name: string;
+  } | null>(null);
+  const [editClientMembers, setEditClientMembers] = useState<
+    { id: number; name: string; position: string; type: "manager" | "member" }[]
+  >([]);
 
   // devManagerId, devUserId, clientManagerId, clientUserId 동기화
   useEffect(() => {
-    const allDevMembers = selectedDevCompanies.flatMap(c => c.members);
-    const allClientMembers = selectedClientCompanies.flatMap(c => c.members);
-    setForm(f => ({
+    const allDevMembers = selectedDevCompanies.flatMap((c) => c.members);
+    const allClientMembers = selectedClientCompanies.flatMap((c) => c.members);
+    setForm((f) => ({
       ...f,
-      devManagerId: allDevMembers.filter(m => m.type === 'manager').map(m => m.id).join(','),
-      devUserId: allDevMembers.map(m => m.id).join(','),
-      clientManagerId: allClientMembers.filter(m => m.type === 'manager').map(m => m.id).join(','),
-      clientUserId: allClientMembers.map(m => m.id).join(','),
+      devManagerId: allDevMembers
+        .filter((m) => m.type === "manager")
+        .map((m) => m.id)
+        .join(","),
+      devUserId: allDevMembers.map((m) => m.id).join(","),
+      clientManagerId: allClientMembers
+        .filter((m) => m.type === "manager")
+        .map((m) => m.id)
+        .join(","),
+      clientUserId: allClientMembers.map((m) => m.id).join(","),
     }));
   }, [selectedDevCompanies, selectedClientCompanies]);
 
   useEffect(() => {
-    const allDevMembers = selectedDevCompanies.flatMap(c => c.members);
-    const allClientMembers = selectedClientCompanies.flatMap(c => c.members);
+    const allDevMembers = selectedDevCompanies.flatMap((c) => c.members);
+    const allClientMembers = selectedClientCompanies.flatMap((c) => c.members);
   }, [selectedDevCompanies, selectedClientCompanies]);
 
-  // 개발사 추가 모달에서 선택된 회사/멤버 반영
-  const handleDevModalDone = (company: any, members: any) => {
-    setSelectedDevCompanies(prev => {
-      // 이미 등록된 회사면 덮어쓰기, 아니면 추가
-      const exists = prev.find(c => c.company.id === company.id);
+  // 개발사 추가 모달에서 선택된 업체/멤버 반영
+  const handleDevCompanyDone = (
+    company: { id: number; name: string },
+    members: {
+      id: number;
+      name: string;
+      position: string;
+      type: "manager" | "member";
+    }[]
+  ) => {
+    setSelectedDevCompanies((prev) => {
+      // 이미 등록된 업체면 덮어쓰기, 아니면 추가
+      const exists = prev.find((c) => c.company.id === company.id);
       if (exists) {
-        return prev.map(c => c.company.id === company.id ? { company, members } : c);
+        return prev.map((c) =>
+          c.company.id === company.id ? { company, members } : c
+        );
       } else {
         return [...prev, { company, members }];
       }
@@ -77,12 +121,22 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
     setShowDevModal(false);
   };
 
-  // 고객사 추가 모달에서 선택된 회사/멤버 반영
-  const handleClientModalDone = (company: any, members: any) => {
-    setSelectedClientCompanies(prev => {
-      const exists = prev.find(c => c.company.id === company.id);
+  // 고객사 추가 모달에서 선택된 업체/멤버 반영
+  const handleClientCompanyDone = (
+    company: { id: number; name: string },
+    members: {
+      id: number;
+      name: string;
+      position: string;
+      type: "manager" | "member";
+    }[]
+  ) => {
+    setSelectedClientCompanies((prev) => {
+      const exists = prev.find((c) => c.company.id === company.id);
       if (exists) {
-        return prev.map(c => c.company.id === company.id ? { company, members } : c);
+        return prev.map((c) =>
+          c.company.id === company.id ? { company, members } : c
+        );
       } else {
         return [...prev, { company, members }];
       }
@@ -94,8 +148,10 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
   useEffect(() => {
     if (open) {
       const original = document.body.style.overflow;
-      document.body.style.overflow = 'hidden';
-      return () => { document.body.style.overflow = original; };
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.body.style.overflow = original;
+      };
     }
   }, [open]);
 
@@ -109,8 +165,15 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
 
   const handleCreateProject = async () => {
     // 모든 필드 입력 체크
-    if (!form.name || !form.description || !form.startDate || !form.endDate || selectedDevCompanies.length === 0 || selectedClientCompanies.length === 0) {
-      alert('모든 필드를 입력하세요');
+    if (
+      !form.name ||
+      !form.description ||
+      !form.startDate ||
+      !form.endDate ||
+      selectedDevCompanies.length === 0 ||
+      selectedClientCompanies.length === 0
+    ) {
+      alert("모든 필드를 입력하세요");
       return;
     }
     if (fetchProjects) {
@@ -131,23 +194,35 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
         startDate: form.startDate,
         endDate: form.endDate,
         devManagerId: form.devManagerId
-          ? form.devManagerId.split(',').map((s: any) => Number(s.trim())).filter(Boolean)
+          ? form.devManagerId
+              .split(",")
+              .map((s: any) => Number(s.trim()))
+              .filter(Boolean)
           : [],
         clientManagerId: form.clientManagerId
-          ? form.clientManagerId.split(',').map((s: any) => Number(s.trim())).filter(Boolean)
+          ? form.clientManagerId
+              .split(",")
+              .map((s: any) => Number(s.trim()))
+              .filter(Boolean)
           : [],
         devUserId: form.devUserId
-          ? form.devUserId.split(',').map((s: any) => Number(s.trim())).filter(Boolean)
+          ? form.devUserId
+              .split(",")
+              .map((s: any) => Number(s.trim()))
+              .filter(Boolean)
           : [],
         clientUserId: form.clientUserId
-          ? form.clientUserId.split(',').map((s: any) => Number(s.trim())).filter(Boolean)
+          ? form.clientUserId
+              .split(",")
+              .map((s: any) => Number(s.trim()))
+              .filter(Boolean)
           : [],
       };
-      await api.post('/api/projects', payload);
+      await api.post("/api/projects", payload);
       if (fetchProjects) fetchProjects(0);
       onClose();
     } catch (e) {
-      alert('프로젝트 생성에 실패했습니다.');
+      alert("프로젝트 생성에 실패했습니다.");
     }
   };
 
@@ -191,51 +266,118 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
           position: "relative",
         }}
       >
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 4 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginBottom: 4,
+          }}
+        >
           <h2 style={{ fontSize: 28, fontWeight: 700 }}>새 프로젝트 생성</h2>
-          <div style={{ display: 'flex', gap: 8 }}>
-            <button style={{ background: '#2563eb', color: '#fff', border: 0, borderRadius: 4, padding: '6px 16px', fontWeight: 500, fontSize: 15, cursor: 'pointer' }}>회사생성</button>
-            <button style={{ background: '#19c37d', color: '#fff', border: 0, borderRadius: 4, padding: '6px 16px', fontWeight: 500, fontSize: 15, cursor: 'pointer' }}>멤버생성</button>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button
+              style={{
+                background: "#2563eb",
+                color: "#fff",
+                border: 0,
+                borderRadius: 4,
+                padding: "6px 16px",
+                fontWeight: 500,
+                fontSize: 15,
+                cursor: "pointer",
+              }}
+            >
+              업체 등록
+            </button>
+            <button
+              style={{
+                background: "#19c37d",
+                color: "#fff",
+                border: 0,
+                borderRadius: 4,
+                padding: "6px 16px",
+                fontWeight: 500,
+                fontSize: 15,
+                cursor: "pointer",
+              }}
+            >
+              멤버생성
+            </button>
           </div>
         </div>
-        <div style={{ color: "#888", marginBottom: 32 }}>새로운 프로젝트의 정보를 입력해주세요</div>
+        <div style={{ color: "#888", marginBottom: 32 }}>
+          새로운 프로젝트의 정보를 입력해주세요
+        </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
           {/* 프로젝트명, 개요 */}
           <div>
             <div style={{ fontWeight: 600, marginBottom: 8 }}>프로젝트명 *</div>
             <input
-              style={{ width: "100%", padding: 12, borderRadius: 6, border: "1px solid #eee", marginBottom: 20 }}
+              style={{
+                width: "100%",
+                padding: 12,
+                borderRadius: 6,
+                border: "1px solid #eee",
+                marginBottom: 20,
+              }}
               placeholder="프로젝트 이름을 입력하세요"
               value={form.name}
-              onChange={e => setForm({ ...form, name: e.target.value })}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
             />
             <div style={{ fontWeight: 600, marginBottom: 8 }}>개요 *</div>
             <textarea
-              style={{ width: "100%", minHeight: 90, maxHeight: 300, padding: 12, borderRadius: 6, border: "1px solid #eee", resize: "none", overflowY: "auto" }}
+              style={{
+                width: "100%",
+                minHeight: 90,
+                maxHeight: 300,
+                padding: 12,
+                borderRadius: 6,
+                border: "1px solid #eee",
+                resize: "none",
+                overflowY: "auto",
+              }}
               placeholder="프로젝트 개요를 상세히 입력하세요..."
               value={form.description}
-              onChange={e => setForm({ ...form, description: e.target.value })}
+              onChange={(e) =>
+                setForm({ ...form, description: e.target.value })
+              }
               rows={4}
             />
           </div>
           {/* 프로젝트 기간 */}
           <div>
-            <div style={{ fontWeight: 600, marginBottom: 8 }}>프로젝트 기간 *</div>
+            <div style={{ fontWeight: 600, marginBottom: 8 }}>
+              프로젝트 기간 *
+            </div>
             <div style={{ display: "flex", gap: 16 }}>
               <div style={{ flex: 1 }}>
                 <div style={{ marginBottom: 4 }}>시작일 *</div>
                 <div
                   style={{ width: "100%" }}
-                  onClick={e => {
-                    const input = (e.currentTarget.querySelector('input') as HTMLInputElement);
+                  onClick={(e) => {
+                    const input = e.currentTarget.querySelector(
+                      "input"
+                    ) as HTMLInputElement;
                     if (input) input.showPicker && input.showPicker();
                   }}
                 >
                   <input
                     type="date"
-                    style={{ width: "100%", padding: 10, borderRadius: 6, border: "1px solid #eee" }}
+                    style={{
+                      width: "100%",
+                      padding: 10,
+                      borderRadius: 6,
+                      border: "1px solid #eee",
+                    }}
                     value={form.startDate}
-                    onChange={e => setForm(prev => ({ ...prev, startDate: e.target.value, endDate: "" }))}
+                    onChange={(e) =>
+                      setForm((prev) => ({
+                        ...prev,
+                        startDate: e.target.value,
+                        endDate: "",
+                      }))
+                    }
                   />
                 </div>
               </div>
@@ -243,16 +385,25 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
                 <div style={{ marginBottom: 4 }}>마감일 *</div>
                 <div
                   style={{ width: "100%" }}
-                  onClick={e => {
-                    const input = (e.currentTarget.querySelector('input') as HTMLInputElement);
+                  onClick={(e) => {
+                    const input = e.currentTarget.querySelector(
+                      "input"
+                    ) as HTMLInputElement;
                     if (input) input.showPicker && input.showPicker();
                   }}
                 >
                   <input
                     type="date"
-                    style={{ width: "100%", padding: 10, borderRadius: 6, border: "1px solid #eee" }}
+                    style={{
+                      width: "100%",
+                      padding: 10,
+                      borderRadius: 6,
+                      border: "1px solid #eee",
+                    }}
                     value={form.endDate}
-                    onChange={e => setForm({ ...form, endDate: e.target.value })}
+                    onChange={(e) =>
+                      setForm({ ...form, endDate: e.target.value })
+                    }
                     min={form.startDate || undefined}
                     disabled={!form.startDate}
                   />
@@ -265,60 +416,188 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
             <div style={{ fontWeight: 600, marginBottom: 8 }}>담당 정보</div>
             <div style={{ display: "flex", gap: 24 }}>
               <div style={{ flex: 1 }}>
-                <div style={{ display: "flex", alignItems: "center", marginBottom: 8 }}>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    marginBottom: 8,
+                  }}
+                >
                   <span style={{ fontWeight: 500 }}>개발사 선택 *</span>
-                  <button style={{ marginLeft: 12, background: "#19c37d", color: "#fff", border: 0, borderRadius: 4, padding: "4px 12px", cursor: "pointer" }} onClick={() => setShowDevModal(true)}>+ 개발사 추가</button>
+                  <button
+                    style={{
+                      marginLeft: 12,
+                      background: "#19c37d",
+                      color: "#fff",
+                      border: 0,
+                      borderRadius: 4,
+                      padding: "4px 12px",
+                      cursor: "pointer",
+                    }}
+                    onClick={() => setShowDevModal(true)}
+                  >
+                    + 개발사 추가
+                  </button>
                 </div>
                 {/* 여러 개발사/멤버 표시 (이동) */}
                 {selectedDevCompanies.map(({ company, members }) => (
-                  <div key={company.id} style={{ marginBottom: 16, background: "#f4f6fa", borderRadius: 8, padding: 16, position: 'relative' }}>
-                    <div style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
-                      <div style={{ fontWeight: 600 }}>선택된 개발사: {company.name}</div>
+                  <div
+                    key={company.id}
+                    style={{
+                      marginBottom: 16,
+                      background: "#f4f6fa",
+                      borderRadius: 8,
+                      padding: 16,
+                      position: "relative",
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        marginBottom: 4,
+                      }}
+                    >
+                      <div style={{ fontWeight: 600 }}>
+                        선택된 개발사: {company.name}
+                      </div>
                       <button
-                        style={{ marginLeft: 8, background: '#eee', border: 0, color: '#222', fontSize: 14, borderRadius: 4, padding: '2px 10px', cursor: 'pointer' }}
+                        style={{
+                          marginLeft: 8,
+                          background: "#eee",
+                          border: 0,
+                          color: "#222",
+                          fontSize: 14,
+                          borderRadius: 4,
+                          padding: "2px 10px",
+                          cursor: "pointer",
+                        }}
                         onClick={() => {
                           setEditDevCompany(company);
                           setEditDevMembers(members);
                           setShowDevModal(true);
                         }}
-                      >수정</button>
+                      >
+                        수정
+                      </button>
                       <button
-                        style={{ marginLeft: 8, background: 'transparent', border: 0, color: '#888', fontSize: 18, cursor: 'pointer' }}
-                        onClick={() => setSelectedDevCompanies(prev => prev.filter(c => c.company.id !== company.id))}
+                        style={{
+                          marginLeft: 8,
+                          background: "transparent",
+                          border: 0,
+                          color: "#888",
+                          fontSize: 18,
+                          cursor: "pointer",
+                        }}
+                        onClick={() =>
+                          setSelectedDevCompanies((prev) =>
+                            prev.filter((c) => c.company.id !== company.id)
+                          )
+                        }
                         aria-label="삭제"
-                      >×</button>
+                      >
+                        ×
+                      </button>
                     </div>
-                    <div style={{ marginTop: 8, color: '#555', fontWeight: 500 }}>
+                    <div
+                      style={{ marginTop: 8, color: "#555", fontWeight: 500 }}
+                    >
                       선택된 멤버: {members.length}명
                     </div>
                   </div>
                 ))}
               </div>
               <div style={{ flex: 1 }}>
-                <div style={{ display: "flex", alignItems: "center", marginBottom: 8 }}>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    marginBottom: 8,
+                  }}
+                >
                   <span style={{ fontWeight: 500 }}>고객사 선택 *</span>
-                  <button style={{ marginLeft: 12, background: "#2563eb", color: "#fff", border: 0, borderRadius: 4, padding: "4px 12px", cursor: "pointer" }} onClick={() => { setEditClientCompany(null); setEditClientMembers([]); setShowClientModal(true); }}>+ 고객사 추가</button>
+                  <button
+                    style={{
+                      marginLeft: 12,
+                      background: "#2563eb",
+                      color: "#fff",
+                      border: 0,
+                      borderRadius: 4,
+                      padding: "4px 12px",
+                      cursor: "pointer",
+                    }}
+                    onClick={() => {
+                      setEditClientCompany(null);
+                      setEditClientMembers([]);
+                      setShowClientModal(true);
+                    }}
+                  >
+                    + 고객사 추가
+                  </button>
                 </div>
                 {/* 여러 고객사/멤버 표시 (이동) */}
                 {selectedClientCompanies.map(({ company, members }) => (
-                  <div key={company.id} style={{ marginBottom: 16, background: "#eaf6ff", borderRadius: 8, padding: 16, position: 'relative' }}>
-                    <div style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
-                      <div style={{ fontWeight: 600 }}>선택된 고객사: {company.name}</div>
+                  <div
+                    key={company.id}
+                    style={{
+                      marginBottom: 16,
+                      background: "#eaf6ff",
+                      borderRadius: 8,
+                      padding: 16,
+                      position: "relative",
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        marginBottom: 4,
+                      }}
+                    >
+                      <div style={{ fontWeight: 600 }}>
+                        선택된 고객사: {company.name}
+                      </div>
                       <button
-                        style={{ marginLeft: 8, background: '#eee', border: 0, color: '#222', fontSize: 14, borderRadius: 4, padding: '2px 10px', cursor: 'pointer' }}
+                        style={{
+                          marginLeft: 8,
+                          background: "#eee",
+                          border: 0,
+                          color: "#222",
+                          fontSize: 14,
+                          borderRadius: 4,
+                          padding: "2px 10px",
+                          cursor: "pointer",
+                        }}
                         onClick={() => {
                           setEditClientCompany(company);
                           setEditClientMembers(members);
                           setShowClientModal(true);
                         }}
-                      >수정</button>
+                      >
+                        수정
+                      </button>
                       <button
-                        style={{ marginLeft: 8, background: 'transparent', border: 0, color: '#888', fontSize: 18, cursor: 'pointer' }}
-                        onClick={() => setSelectedClientCompanies(prev => prev.filter(c => c.company.id !== company.id))}
+                        style={{
+                          marginLeft: 8,
+                          background: "transparent",
+                          border: 0,
+                          color: "#888",
+                          fontSize: 18,
+                          cursor: "pointer",
+                        }}
+                        onClick={() =>
+                          setSelectedClientCompanies((prev) =>
+                            prev.filter((c) => c.company.id !== company.id)
+                          )
+                        }
                         aria-label="삭제"
-                      >×</button>
+                      >
+                        ×
+                      </button>
                     </div>
-                    <div style={{ marginTop: 8, color: '#555', fontWeight: 500 }}>
+                    <div
+                      style={{ marginTop: 8, color: "#555", fontWeight: 500 }}
+                    >
                       선택된 멤버: {members.length}명
                     </div>
                   </div>
@@ -328,21 +607,55 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
           </div>
         </div>
         {/* 하단 버튼 */}
-        <div style={{ display: "flex", justifyContent: "flex-end", gap: 12, marginTop: 40 }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            gap: 12,
+            marginTop: 40,
+          }}
+        >
           <button
-            style={{ padding: "10px 28px", borderRadius: 6, border: "1px solid #eee", background: "#fff", color: "#222", fontWeight: 500, fontSize: 16, cursor: "pointer" }}
+            style={{
+              padding: "10px 28px",
+              borderRadius: 6,
+              border: "1px solid #eee",
+              background: "#fff",
+              color: "#222",
+              fontWeight: 500,
+              fontSize: 16,
+              cursor: "pointer",
+            }}
             onClick={onClose}
           >
             취소
           </button>
           <button
-            style={{ padding: "10px 28px", borderRadius: 6, border: 0, background: "#aaa", color: "#fff", fontWeight: 500, fontSize: 16, cursor: "pointer" }}
+            style={{
+              padding: "10px 28px",
+              borderRadius: 6,
+              border: 0,
+              background: "#aaa",
+              color: "#fff",
+              fontWeight: 500,
+              fontSize: 16,
+              cursor: "pointer",
+            }}
             onClick={handleReset}
           >
             초기화
           </button>
           <button
-            style={{ padding: "10px 28px", borderRadius: 6, border: 0, background: "#4338ca", color: "#fff", fontWeight: 600, fontSize: 16, cursor: "pointer" }}
+            style={{
+              padding: "10px 28px",
+              borderRadius: 6,
+              border: 0,
+              background: "#4338ca",
+              color: "#fff",
+              fontWeight: 600,
+              fontSize: 16,
+              cursor: "pointer",
+            }}
             onClick={handleCreateProject}
           >
             프로젝트 생성
@@ -350,7 +663,15 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
         </div>
         {/* 닫기 버튼 (오른쪽 상단) */}
         <button
-          style={{ position: "absolute", top: 20, right: 20, background: "transparent", border: 0, fontSize: 24, cursor: "pointer" }}
+          style={{
+            position: "absolute",
+            top: 20,
+            right: 20,
+            background: "transparent",
+            border: 0,
+            fontSize: 24,
+            cursor: "pointer",
+          }}
           onClick={onClose}
           aria-label="닫기"
         >
@@ -359,7 +680,7 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
         {showDevModal && (
           <DevCompanySelectModal
             onClose={() => setShowDevModal(false)}
-            onDone={handleDevModalDone}
+            onDone={handleDevCompanyDone}
             selectedCompany={editDevCompany}
             selectedMembers={editDevMembers}
             selectedDevCompanies={selectedDevCompanies}
@@ -369,7 +690,7 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
         {showClientModal && (
           <DevCompanySelectModal
             onClose={() => setShowClientModal(false)}
-            onDone={handleClientModalDone}
+            onDone={handleClientCompanyDone}
             selectedCompany={editClientCompany}
             selectedMembers={editClientMembers}
             selectedDevCompanies={selectedDevCompanies}
@@ -381,21 +702,47 @@ export default function ProjectCreateModal({ open, onClose, fetchProjects }: Pro
   );
 }
 
-function DevCompanySelectModal({ onClose, onDone, selectedCompany, selectedMembers, selectedDevCompanies = [], selectedClientCompanies = [] }: {
+function DevCompanySelectModal({
+  onClose,
+  onDone,
+  selectedCompany,
+  selectedMembers,
+  selectedDevCompanies = [],
+  selectedClientCompanies = [],
+}: {
   onClose: () => void;
-  onDone: (company: { id: number; name: string }, members: { id: number; name: string; position: string; type: 'manager' | 'member' }[]) => void;
+  onDone: (
+    company: { id: number; name: string },
+    members: {
+      id: number;
+      name: string;
+      position: string;
+      type: "manager" | "member";
+    }[]
+  ) => void;
   selectedCompany?: { id: number; name: string } | null;
-  selectedMembers?: { id: number; name: string; position: string; type: 'manager' | 'member' }[];
+  selectedMembers?: {
+    id: number;
+    name: string;
+    position: string;
+    type: "manager" | "member";
+  }[];
   selectedDevCompanies?: { company: { id: number; name: string } }[];
   selectedClientCompanies?: { company: { id: number; name: string } }[];
 }) {
   const [search, setSearch] = useState("");
-  const [companies, setCompanies] = useState<{ id: number; name: string }[]>([]);
+  const [companies, setCompanies] = useState<{ id: number; name: string }[]>(
+    []
+  );
   const [loading, setLoading] = useState(false);
-  const [selectedCompanyState, setSelectedCompanyState] = useState(selectedCompany ?? null);
+  const [selectedCompanyState, setSelectedCompanyState] = useState(
+    selectedCompany ?? null
+  );
   const [members, setMembers] = useState<Member[]>([]);
   const [memberSearch, setMemberSearch] = useState("");
-  const [selectedMembersState, setSelectedMembersState] = useState(selectedMembers ?? []);
+  const [selectedMembersState, setSelectedMembersState] = useState(
+    selectedMembers ?? []
+  );
 
   // 업체 검색
   useEffect(() => {
@@ -407,11 +754,16 @@ function DevCompanySelectModal({ onClose, onDone, selectedCompany, selectedMembe
         const result = Array.isArray(res.data?.data?.content)
           ? res.data.data.content
           : Array.isArray(res.data?.content)
-            ? res.data.content
-            : Array.isArray(res.data)
-              ? res.data
-              : [];
-        setCompanies(result.filter((c: any) => c && typeof c.id === 'number' && typeof c.name === 'string'));
+          ? res.data.content
+          : Array.isArray(res.data)
+          ? res.data
+          : [];
+        setCompanies(
+          result.filter(
+            (c: any) =>
+              c && typeof c.id === "number" && typeof c.name === "string"
+          )
+        );
         console.log("Companies 응답:", res.data, "최종:", result);
       } catch (e) {
         setCompanies([]);
@@ -422,31 +774,33 @@ function DevCompanySelectModal({ onClose, onDone, selectedCompany, selectedMembe
     return () => clearTimeout(timeout);
   }, [search]);
 
-// 업체 선택 시 멤버 불러오기
-useEffect(() => {
-  if (!selectedCompanyState) return;
-  (async () => {
-    setLoading(true);
-    try {
-      const res = await api.get(`/api/companies/${selectedCompanyState.id}/users`);
+  // 업체 선택 시 멤버 불러오기
+  useEffect(() => {
+    if (!selectedCompanyState) return;
+    (async () => {
+      setLoading(true);
+      try {
+        const res = await api.get(
+          `/api/companies/${selectedCompanyState.id}/users`
+        );
 
-      // ✅ 수정: 배열 형태로 안전하게 추출
-      const result = Array.isArray(res.data?.data)
-        ? res.data.data
-        : Array.isArray(res.data?.content)
+        // ✅ 수정: 배열 형태로 안전하게 추출
+        const result = Array.isArray(res.data?.data)
+          ? res.data.data
+          : Array.isArray(res.data?.content)
           ? res.data.content
           : Array.isArray(res.data)
-            ? res.data
-            : [];
+          ? res.data
+          : [];
 
-      setMembers(result); // ✅ 수정된 멤버 설정
-    } catch (e) {
-      setMembers([]); // ✅ 실패 시 빈 배열
-    } finally {
-      setLoading(false);
-    }
-  })();
-}, [selectedCompanyState]);
+        setMembers(result); // ✅ 수정된 멤버 설정
+      } catch (e) {
+        setMembers([]); // ✅ 실패 시 빈 배열
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [selectedCompanyState]);
 
   // 모달 외부 클릭 시 닫기
   const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -454,19 +808,19 @@ useEffect(() => {
   };
 
   // 멤버 필터링
-  const filteredMembers = members.filter(m => m.name.includes(memberSearch));
+  const filteredMembers = members.filter((m) => m.name.includes(memberSearch));
 
   // 멤버 버튼 클릭 핸들러
-  const handleMemberType = (member: Member, type: 'manager' | 'member') => {
-    setSelectedMembersState(prev => {
+  const handleMemberType = (member: Member, type: "manager" | "member") => {
+    setSelectedMembersState((prev) => {
       // 이미 선택된 멤버인지 확인
-      const exists = prev.find(m => m.id === member.id);
+      const exists = prev.find((m) => m.id === member.id);
       if (exists) {
         // 같은 타입이면 해제, 다른 타입이면 타입만 변경
         if (exists.type === type) {
-          return prev.filter(m => m.id !== member.id);
+          return prev.filter((m) => m.id !== member.id);
         } else {
-          return prev.map(m => m.id === member.id ? { ...m, type } : m);
+          return prev.map((m) => (m.id === member.id ? { ...m, type } : m));
         }
       } else {
         // 새로 추가
@@ -478,42 +832,111 @@ useEffect(() => {
   return (
     <div
       style={{
-        position: "fixed", top: 0, left: 0, width: "100vw", height: "100vh", background: "rgba(0,0,0,0.3)", zIndex: 2000,
-        display: "flex", alignItems: "center", justifyContent: "center"
+        position: "fixed",
+        top: 0,
+        left: 0,
+        width: "100vw",
+        height: "100vh",
+        background: "rgba(0,0,0,0.3)",
+        zIndex: 2000,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
       }}
       onClick={handleOverlayClick}
     >
       <div
-        style={{ background: "#fff", borderRadius: 12, padding: 32, minWidth: 400, maxWidth: 500, width: "90vw", boxShadow: "0 2px 32px rgba(0,0,0,0.18)", position: "relative" }}
+        style={{
+          background: "#fff",
+          borderRadius: 12,
+          padding: 32,
+          minWidth: 400,
+          maxWidth: 500,
+          width: "90vw",
+          boxShadow: "0 2px 32px rgba(0,0,0,0.18)",
+          position: "relative",
+        }}
       >
         {/* ← 업체 다시 선택 버튼 상단 */}
         {selectedCompanyState && (
-          <button style={{ marginBottom: 16, width: "100%", border: 0, borderRadius: 6, background: "#eee", color: "#222", padding: 10, fontWeight: 500, cursor: "pointer" }} onClick={() => setSelectedCompanyState(null)}>← 업체 다시 선택</button>
+          <button
+            style={{
+              marginBottom: 16,
+              width: "100%",
+              border: 0,
+              borderRadius: 6,
+              background: "#eee",
+              color: "#222",
+              padding: 10,
+              fontWeight: 500,
+              cursor: "pointer",
+            }}
+            onClick={() => setSelectedCompanyState(null)}
+          >
+            ← 업체 다시 선택
+          </button>
         )}
-        <h3 style={{ fontSize: 22, fontWeight: 700, marginBottom: 16 }}>업체 선택</h3>
+        <h3 style={{ fontSize: 22, fontWeight: 700, marginBottom: 16 }}>
+          업체 선택
+        </h3>
         {!selectedCompanyState ? (
           <>
             <div style={{ marginBottom: 16 }}>
               <input
-                style={{ width: "100%", padding: 10, borderRadius: 6, border: "1px solid #eee" }}
+                style={{
+                  width: "100%",
+                  padding: 10,
+                  borderRadius: 6,
+                  border: "1px solid #eee",
+                }}
                 placeholder="업체명 검색"
                 value={search}
-                onChange={e => setSearch(e.target.value)}
+                onChange={(e) => setSearch(e.target.value)}
                 autoFocus
               />
             </div>
-            <div style={{ maxHeight: 300, overflowY: "auto", display: "flex", flexDirection: "column", gap: 8 }}>
-              {loading && <div style={{ textAlign: "center", color: "#888" }}>불러오는 중...</div>}
-              {!loading && companies.length === 0 && <div style={{ textAlign: "center", color: "#aaa" }}>검색 결과 없음</div>}
+            <div
+              style={{
+                maxHeight: 300,
+                overflowY: "auto",
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+              }}
+            >
+              {loading && (
+                <div style={{ textAlign: "center", color: "#888" }}>
+                  불러오는 중...
+                </div>
+              )}
+              {!loading && companies.length === 0 && (
+                <div style={{ textAlign: "center", color: "#aaa" }}>
+                  검색 결과 없음
+                </div>
+              )}
               {companies
-                .filter(c =>
-                  !selectedDevCompanies.some(dev => dev.company.id === c.id) &&
-                  !selectedClientCompanies.some(cli => cli.company.id === c.id)
+                .filter(
+                  (c) =>
+                    !selectedDevCompanies.some(
+                      (dev) => dev.company.id === c.id
+                    ) &&
+                    !selectedClientCompanies.some(
+                      (cli) => cli.company.id === c.id
+                    )
                 )
-                .map(c => (
+                .map((c) => (
                   <div
                     key={c.id}
-                    style={{ padding: 14, border: "1px solid #eee", borderRadius: 8, background: "#fafbfc", cursor: "pointer", fontWeight: 500, transition: "box-shadow 0.2s", boxShadow: "0 1px 4px rgba(0,0,0,0.04)" }}
+                    style={{
+                      padding: 14,
+                      border: "1px solid #eee",
+                      borderRadius: 8,
+                      background: "#fafbfc",
+                      cursor: "pointer",
+                      fontWeight: 500,
+                      transition: "box-shadow 0.2s",
+                      boxShadow: "0 1px 4px rgba(0,0,0,0.04)",
+                    }}
                     onClick={() => setSelectedCompanyState(c)}
                   >
                     {c.name}
@@ -523,24 +946,59 @@ useEffect(() => {
           </>
         ) : (
           <>
-            <div style={{ marginBottom: 12, fontWeight: 600 }}>{selectedCompanyState.name}</div>
+            <div style={{ marginBottom: 12, fontWeight: 600 }}>
+              {selectedCompanyState.name}
+            </div>
             <div style={{ margin: "12px 0 16px 0" }}>
               <input
                 placeholder="멤버 이름 검색"
                 value={memberSearch}
-                onChange={e => setMemberSearch(e.target.value)}
-                style={{ width: "100%", padding: 8, borderRadius: 6, border: "1px solid #eee" }}
+                onChange={(e) => setMemberSearch(e.target.value)}
+                style={{
+                  width: "100%",
+                  padding: 8,
+                  borderRadius: 6,
+                  border: "1px solid #eee",
+                }}
               />
             </div>
-            <div style={{ maxHeight: 300, overflowY: "auto", display: "flex", flexDirection: "column", gap: 12 }}>
-              {loading && <div style={{ textAlign: "center", color: "#888" }}>불러오는 중...</div>}
-              {!loading && filteredMembers.length === 0 && <div style={{ textAlign: "center", color: "#aaa" }}>멤버 없음</div>}
-              {filteredMembers.map(member => {
-                const sel = selectedMembersState.find(m => m.id === member.id);
+            <div
+              style={{
+                maxHeight: 300,
+                overflowY: "auto",
+                display: "flex",
+                flexDirection: "column",
+                gap: 12,
+              }}
+            >
+              {loading && (
+                <div style={{ textAlign: "center", color: "#888" }}>
+                  불러오는 중...
+                </div>
+              )}
+              {!loading && filteredMembers.length === 0 && (
+                <div style={{ textAlign: "center", color: "#aaa" }}>
+                  멤버 없음
+                </div>
+              )}
+              {filteredMembers.map((member) => {
+                const sel = selectedMembersState.find(
+                  (m) => m.id === member.id
+                );
                 return (
                   <div
                     key={member.id}
-                    style={{ display: "flex", alignItems: "center", justifyContent: "space-between", border: "1px solid #eee", borderRadius: 8, padding: 14, background: "#fafbfc", transition: "box-shadow 0.2s", boxShadow: "0 1px 4px rgba(0,0,0,0.04)" }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      border: "1px solid #eee",
+                      borderRadius: 8,
+                      padding: 14,
+                      background: "#fafbfc",
+                      transition: "box-shadow 0.2s",
+                      boxShadow: "0 1px 4px rgba(0,0,0,0.04)",
+                    }}
                   >
                     <div>
                       <div style={{ fontWeight: 600 }}>{member.name}</div>
@@ -548,32 +1006,78 @@ useEffect(() => {
                     </div>
                     <div style={{ display: "flex", gap: 8 }}>
                       <button
-                        style={{ border: 0, borderRadius: 4, background: sel?.type === 'manager' ? '#4338ca' : '#eee', color: sel?.type === 'manager' ? '#fff' : '#222', padding: "4px 12px", cursor: "pointer" }}
-                        onClick={() => handleMemberType(member, 'manager')}
-                      >담당자</button>
+                        style={{
+                          border: 0,
+                          borderRadius: 4,
+                          background:
+                            sel?.type === "manager" ? "#4338ca" : "#eee",
+                          color: sel?.type === "manager" ? "#fff" : "#222",
+                          padding: "4px 12px",
+                          cursor: "pointer",
+                        }}
+                        onClick={() => handleMemberType(member, "manager")}
+                      >
+                        담당자
+                      </button>
                       <button
-                        style={{ border: 0, borderRadius: 4, background: sel?.type === 'member' ? '#19c37d' : '#eee', color: sel?.type === 'member' ? '#fff' : '#222', padding: "4px 12px", cursor: "pointer" }}
-                        onClick={() => handleMemberType(member, 'member')}
-                      >멤버</button>
+                        style={{
+                          border: 0,
+                          borderRadius: 4,
+                          background:
+                            sel?.type === "member" ? "#19c37d" : "#eee",
+                          color: sel?.type === "member" ? "#fff" : "#222",
+                          padding: "4px 12px",
+                          cursor: "pointer",
+                        }}
+                        onClick={() => handleMemberType(member, "member")}
+                      >
+                        멤버
+                      </button>
                     </div>
                   </div>
                 );
               })}
             </div>
             <button
-              style={{ marginTop: 24, width: "100%", border: 0, borderRadius: 6, background: "#4338ca", color: "#fff", padding: 10, fontWeight: 500, cursor: "pointer" }}
+              style={{
+                marginTop: 24,
+                width: "100%",
+                border: 0,
+                borderRadius: 6,
+                background: "#4338ca",
+                color: "#fff",
+                padding: 10,
+                fontWeight: 500,
+                cursor: "pointer",
+              }}
               onClick={() => {
                 if (selectedMembersState.length === 0) {
-                  alert('한 명 이상 선택해야 합니다');
+                  alert("한 명 이상 선택해야 합니다");
                   return;
                 }
                 onDone(selectedCompanyState, selectedMembersState);
               }}
-            >등록</button>
+            >
+              등록
+            </button>
           </>
         )}
-        <button style={{ position: "absolute", top: 16, right: 16, background: "transparent", border: 0, fontSize: 22, cursor: "pointer" }} onClick={onClose} aria-label="닫기">×</button>
+        <button
+          style={{
+            position: "absolute",
+            top: 16,
+            right: 16,
+            background: "transparent",
+            border: 0,
+            fontSize: 22,
+            cursor: "pointer",
+          }}
+          onClick={onClose}
+          aria-label="닫기"
+        >
+          ×
+        </button>
       </div>
     </div>
   );
-} 
+}

--- a/src/features/user/components/MemberEditModal/MemberEditModal.tsx
+++ b/src/features/user/components/MemberEditModal/MemberEditModal.tsx
@@ -92,7 +92,7 @@ export default function MemberEditModal({
         setCompanies(response.data.data.content);
       } catch (error) {
         console.error("Failed to fetch companies:", error);
-        alert("회사 목록을 불러오는 데 실패했습니다.");
+        alert("업체 목록을 불러오는 데 실패했습니다.");
       }
     };
     fetchCompanies();
@@ -127,7 +127,7 @@ export default function MemberEditModal({
 
     const isValidCompany = companies.some((c) => c.id === formData.companyId);
     if (!isValidCompany) {
-      alert("선택된 회사가 유효하지 않습니다.");
+      alert("선택된 업체가 유효하지 않습니다.");
       return;
     }
 

--- a/src/features/user/components/MemberEditModal/MemberEditModal.tsx
+++ b/src/features/user/components/MemberEditModal/MemberEditModal.tsx
@@ -104,7 +104,8 @@ export default function MemberEditModal({
     const { name, value } = e.target;
     setFormData((prev) => ({
       ...prev,
-      [name]: name === "companyId" ? (value === "" ? "" : Number(value)) : value,
+      [name]:
+        name === "companyId" ? (value === "" ? "" : Number(value)) : value,
       role: name === "role" ? (value as "Manager" | "Member") : prev.role,
     }));
   };
@@ -112,7 +113,11 @@ export default function MemberEditModal({
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (formData.companyId === "" || formData.companyId === 0 || formData.companyId === undefined) {
+    if (
+      formData.companyId === "" ||
+      formData.companyId === 0 ||
+      formData.companyId === undefined
+    ) {
       onEdit({
         ...formData,
         companyId: undefined,
@@ -129,7 +134,8 @@ export default function MemberEditModal({
     onEdit({
       ...formData,
       phone: formData.phone.replace(/\D/g, ""),
-      companyId: typeof formData.companyId === "number" ? formData.companyId : undefined,
+      companyId:
+        typeof formData.companyId === "number" ? formData.companyId : undefined,
     });
   };
 
@@ -172,20 +178,20 @@ export default function MemberEditModal({
               </FormRow>
             </FormSection>
 
-            {/* 회사 + 직책 */}
+            {/* 업체 + 직책 */}
             <FormSection>
               <FormRow>
                 <FormGroup>
                   <Label>
                     <IoBusinessOutline />
-                    회사
+                    업체
                   </Label>
                   <Select
                     name="companyId"
                     value={formData.companyId.toString() || ""}
                     onChange={handleChange}
                   >
-                    <option value="">회사 선택</option>
+                    <option value="">업체 선택</option>
                     {companies.map((company) => (
                       <option key={company.id} value={company.id.toString()}>
                         {company.name}

--- a/src/features/user/components/MemberRegisterModal/MemberRegisterModal.tsx
+++ b/src/features/user/components/MemberRegisterModal/MemberRegisterModal.tsx
@@ -57,7 +57,9 @@ const MemberRegisterModal: React.FC<MemberRegisterModalProps> = ({
     fetchCompanies();
   }, []);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
     const { name, value } = e.target;
     setFormData((prev) => ({
       ...prev,
@@ -77,7 +79,8 @@ const MemberRegisterModal: React.FC<MemberRegisterModalProps> = ({
       email: formData.email,
       phone: cleanedPhone,
       position: formData.position,
-      companyId: formData.companyId === "" ? undefined : Number(formData.companyId),
+      companyId:
+        formData.companyId === "" ? undefined : Number(formData.companyId),
     });
   };
 
@@ -135,7 +138,7 @@ const MemberRegisterModal: React.FC<MemberRegisterModalProps> = ({
                 <S.FormGroup>
                   <S.Label>
                     <IoBusinessOutline />
-                    회사
+                    업체
                   </S.Label>
                   <Select
                     options={companies.map((company) => ({
@@ -144,12 +147,18 @@ const MemberRegisterModal: React.FC<MemberRegisterModalProps> = ({
                     }))}
                     isClearable
                     isSearchable
-                    placeholder="회사 선택"
+                    placeholder="업체 선택"
                     value={
                       companies && formData.companyId
                         ? companies
-                            .map((company) => ({ value: company.id, label: company.name }))
-                            .find((option) => option.value === Number(formData.companyId)) || null
+                            .map((company) => ({
+                              value: company.id,
+                              label: company.name,
+                            }))
+                            .find(
+                              (option) =>
+                                option.value === Number(formData.companyId)
+                            ) || null
                         : null
                     }
                     onChange={(selected) => {

--- a/src/features/user/components/MemberRegisterModal/MemberRegisterModal.tsx
+++ b/src/features/user/components/MemberRegisterModal/MemberRegisterModal.tsx
@@ -51,7 +51,7 @@ const MemberRegisterModal: React.FC<MemberRegisterModalProps> = ({
         const res = await api.get("/api/companies");
         setCompanies(res.data.data.content); // 응답 구조에 따라 조정
       } catch (error) {
-        console.error("회사 목록을 불러오는 데 실패했습니다", error);
+        console.error("업체 목록을 불러오는 데 실패했습니다", error);
       }
     };
     fetchCompanies();
@@ -133,7 +133,7 @@ const MemberRegisterModal: React.FC<MemberRegisterModalProps> = ({
                 <S.FormGroup />
               </S.FormRow>
 
-              {/* 회사 + 직책 */}
+              {/* 업체 + 직책 */}
               <S.FormRow>
                 <S.FormGroup>
                   <S.Label>

--- a/src/features/user/pages/MemberDetailPage.tsx
+++ b/src/features/user/pages/MemberDetailPage.tsx
@@ -272,7 +272,7 @@ const MemberDetailPage: React.FC = () => {
         const response = await api.get("/api/companies?size=1000"); // Fetch all companies
         setCompanies(response.data.data.content);
       } catch (error) {
-        console.error("회사 목록을 불러오는 데 실패했습니다.:", error);
+        console.error("업체 목록을 불러오는 데 실패했습니다.:", error);
       }
     };
     fetchCompanies();

--- a/src/features/user/pages/MemberDetailPage.tsx
+++ b/src/features/user/pages/MemberDetailPage.tsx
@@ -4,17 +4,8 @@ import { useParams, useNavigate } from "react-router-dom";
 import api from "@/api/axios";
 import { type Member, formatTelNo } from "../pages/MemberPage";
 import MemberEditModal from "../components/MemberEditModal/MemberEditModal";
-import {
-  showErrorToast,
-  showSuccessToast,
-} from "@/utils/errorHandler";
-import {
-  FiUser,
-  FiMail,
-  FiPhone,
-  FiBriefcase,
-  FiTag,
-} from "react-icons/fi";
+import { showErrorToast, showSuccessToast } from "@/utils/errorHandler";
+import { FiUser, FiMail, FiPhone, FiBriefcase, FiTag } from "react-icons/fi";
 
 interface Company {
   id: number;
@@ -122,7 +113,7 @@ const EditButton = styled(ActionButton)`
   color: #374151;
   border: 2px solid #e5e7eb;
   box-shadow: 0 2px 4px rgba(107, 114, 128, 0.2);
-  
+
   &:hover {
     background: linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%);
     border-color: #fef3c7;
@@ -333,7 +324,8 @@ const MemberDetailPage: React.FC = () => {
   if (error) return <PageContainer>오류: {error}</PageContainer>;
   if (!member) return <PageContainer>회원을 찾을 수 없습니다.</PageContainer>;
 
-  const companyName = companies.find(c => c.id === member.companyId)?.name || '소속 없음';
+  const companyName =
+    companies.find((c) => c.id === member.companyId)?.name || "소속 없음";
 
   return (
     <PageContainer>
@@ -346,9 +338,7 @@ const MemberDetailPage: React.FC = () => {
       )}
       <PageHeaderSection>
         <PageTitle>회원 상세 정보</PageTitle>
-        <PageSubtitle>
-          해당 회원의 상세 정보를 한 눈에 확인하세요
-        </PageSubtitle>
+        <PageSubtitle>해당 회원의 상세 정보를 한 눈에 확인하세요</PageSubtitle>
       </PageHeaderSection>
 
       <MainContentArea>
@@ -375,12 +365,16 @@ const MemberDetailPage: React.FC = () => {
           <InfoCard>
             <CardTitle>기본 정보</CardTitle>
             <DetailItem>
-              <DetailIcon><FiBriefcase size={18} /></DetailIcon>
-              <DetailLabel>소속 회사</DetailLabel>
+              <DetailIcon>
+                <FiBriefcase size={18} />
+              </DetailIcon>
+              <DetailLabel>소속 업체</DetailLabel>
               <DetailValue>{companyName}</DetailValue>
             </DetailItem>
             <DetailItem>
-              <DetailIcon><FiTag size={18} /></DetailIcon>
+              <DetailIcon>
+                <FiTag size={18} />
+              </DetailIcon>
               <DetailLabel>직책</DetailLabel>
               <DetailValue>{member.position}</DetailValue>
             </DetailItem>
@@ -388,16 +382,20 @@ const MemberDetailPage: React.FC = () => {
           <InfoCard>
             <CardTitle>연락처 정보</CardTitle>
             <DetailItem>
-              <DetailIcon><FiMail size={18} /></DetailIcon>
+              <DetailIcon>
+                <FiMail size={18} />
+              </DetailIcon>
               <DetailLabel>이메일</DetailLabel>
               <DetailValue>{member.email}</DetailValue>
             </DetailItem>
             <DetailItem>
-              <DetailIcon><FiPhone size={18} /></DetailIcon>
+              <DetailIcon>
+                <FiPhone size={18} />
+              </DetailIcon>
               <DetailLabel>연락처</DetailLabel>
               <DetailValue>{formatTelNo(member.phone)}</DetailValue>
             </DetailItem>
-             <DetailItem>
+            <DetailItem>
               <DetailLabel>비밀번호 재설정</DetailLabel>
               <DetailValue>
                 <ResetPasswordLink onClick={handleResetPassword}>

--- a/src/features/user/pages/MemberDetailPage.tsx
+++ b/src/features/user/pages/MemberDetailPage.tsx
@@ -56,9 +56,10 @@ const PageTitle = styled.h1`
 `;
 
 const PageSubtitle = styled.p`
-  color: #6b7280;
-  font-size: 14px;
-  padding-left: 16px;
+  color: #bdbdbd;
+  font-size: 0.9rem;
+  margin-top: 6.6px;
+  margin-bottom: 18px;
 `;
 
 const MainContentArea = styled.div`
@@ -338,7 +339,9 @@ const MemberDetailPage: React.FC = () => {
       )}
       <PageHeaderSection>
         <PageTitle>회원 상세 정보</PageTitle>
-        <PageSubtitle>해당 회원의 상세 정보를 한 눈에 확인하세요</PageSubtitle>
+        <PageSubtitle>
+          프로젝트 관리 시스템의 회원 정보를 한눈에 확인하세요
+        </PageSubtitle>
       </PageHeaderSection>
 
       <MainContentArea>

--- a/src/features/user/pages/MemberPage.tsx
+++ b/src/features/user/pages/MemberPage.tsx
@@ -753,7 +753,7 @@ export default function MemberPage() {
           </SelectDropdown>
         </FilterGroup>
         <FilterGroup>
-          <FilterLabel>권한</FilterLabel>
+          <FilterLabel>직책</FilterLabel>
           <SelectButton
             $hasValue={filters.position !== ""}
             $color="#fdb924"
@@ -762,7 +762,7 @@ export default function MemberPage() {
           >
             <FiUsers size={16} />
             <span className="select-value">
-              {filters.position || "모든 권한"}
+              {filters.position || "모든 직책"}
             </span>
             <FiChevronDown size={16} />
           </SelectButton>
@@ -771,7 +771,7 @@ export default function MemberPage() {
               $isSelected={filters.position === ""}
               onClick={() => handlePositionSelect("")}
             >
-              모든 권한
+              모든 직책
             </SelectOption>
             {uniquePositions.map((position) => (
               <SelectOption
@@ -839,7 +839,7 @@ export default function MemberPage() {
             <TableRow>
               <TableHeader>회원</TableHeader>
               <TableHeader>업체</TableHeader>
-              <TableHeader>권한</TableHeader>
+              <TableHeader>직책</TableHeader>
               <TableHeader>연락처</TableHeader>
             </TableRow>
           </TableHead>
@@ -858,11 +858,17 @@ export default function MemberPage() {
                       }}
                       onClick={() => handleMemberClick(member)}
                     >
-                      {member.role === "ROLE_ADMIN" ? (
+                      {member.position === "admin" ? (
                         <LuUserRoundCog
                           size={14}
                           style={{ color: "#8b5cf6" }}
                         />
+                      ) : member.position === "developer" ||
+                        member.position === "개발자" ? (
+                        <FiUser size={14} style={{ color: "#3b82f6" }} />
+                      ) : member.position === "client" ||
+                        member.position === "고객" ? (
+                        <FiUser size={14} style={{ color: "#10b981" }} />
                       ) : (
                         <FiUser size={14} style={{ color: "#6b7280" }} />
                       )}
@@ -900,7 +906,7 @@ export default function MemberPage() {
                         gap: "8px",
                       }}
                     >
-                      <IoPeopleOutline size={14} style={{ color: "#3b82f6" }} />
+                      <FiUsers size={14} style={{ color: "#3b82f6" }} />
                       <span style={{ fontWeight: "500" }}>
                         {member.position}
                       </span>

--- a/src/features/user/pages/MemberPage.tsx
+++ b/src/features/user/pages/MemberPage.tsx
@@ -431,7 +431,9 @@ export default function MemberPage() {
       setCompanyError(null);
     } catch (err: unknown) {
       setCompanies([]); // 회사가 없을 때도 빈 배열로
-      setCompanyError("회사를 불러오지 못했습니다. 회사가 등록되어 있지 않을 수 있습니다.");
+      setCompanyError(
+        "회사를 불러오지 못했습니다. 회사가 등록되어 있지 않을 수 있습니다."
+      );
       console.error("Failed to fetch companies:", err);
     }
   };
@@ -500,34 +502,37 @@ export default function MemberPage() {
     navigate(`/member/${member.id}`);
   };
 
-  const handleRegister = useCallback(async (data: MemberData) => {
-    try {
-      const newMember = {
-        ...data,
-        role: "user", // API에만 추가
-      };
-      const response = await api.post("/api/admin", newMember);
+  const handleRegister = useCallback(
+    async (data: MemberData) => {
+      try {
+        const newMember = {
+          ...data,
+          role: "user", // API에만 추가
+        };
+        const response = await api.post("/api/admin", newMember);
 
-      const { username, password } = response.data.data;
-      const fileContent = `Username: ${username}\nPassword: ${password}`;
-      const blob = new Blob([fileContent], { type: "text/plain" });
-      const fileUrl = URL.createObjectURL(blob);
+        const { username, password } = response.data.data;
+        const fileContent = `Username: ${username}\nPassword: ${password}`;
+        const blob = new Blob([fileContent], { type: "text/plain" });
+        const fileUrl = URL.createObjectURL(blob);
 
-      const link = document.createElement("a");
-      link.href = fileUrl;
-      link.download = "member_credentials.txt";
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+        const link = document.createElement("a");
+        link.href = fileUrl;
+        link.download = "member_credentials.txt";
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
 
-      fetchMembers();
-      alert("회원 등록이 완료되었습니다!");
-      setModalOpen(false);
-    } catch (error: unknown) {
-      console.error("Error registering member:", error);
-      alert("회원 등록 중 오류가 발생했습니다.");
-    }
-  }, [fetchMembers]);
+        fetchMembers();
+        alert("회원 등록이 완료되었습니다!");
+        setModalOpen(false);
+      } catch (error: unknown) {
+        console.error("Error registering member:", error);
+        alert("회원 등록 중 오류가 발생했습니다.");
+      }
+    },
+    [fetchMembers]
+  );
 
   if (loading)
     return (
@@ -563,12 +568,14 @@ export default function MemberPage() {
           프로젝트 관리 시스템의 회원 정보를 한눈에 확인하세요.
         </Subtitle>
         {companyError && (
-          <div style={{ color: "#ef4444", marginBottom: "12px" }}>{companyError}</div>
+          <div style={{ color: "#ef4444", marginBottom: "12px" }}>
+            {companyError}
+          </div>
         )}
       </HeaderSection>
       <FilterBar>
         <FilterGroup>
-          <FilterLabel>회사</FilterLabel>
+          <FilterLabel>업체</FilterLabel>
           <SelectButton
             $hasValue={filters.companyId !== ""}
             $color="#fdb924"
@@ -578,8 +585,9 @@ export default function MemberPage() {
             <FiHome size={16} />
             <span className="select-value">
               {(Array.isArray(companies) &&
-                companies.find((c) => c.id === parseInt(filters.companyId))?.name) ||
-                "모든 회사"}
+                companies.find((c) => c.id === parseInt(filters.companyId))
+                  ?.name) ||
+                "모든 업체"}
             </span>
             <FiChevronDown size={16} />
           </SelectButton>
@@ -588,11 +596,11 @@ export default function MemberPage() {
               $isSelected={filters.companyId === ""}
               onClick={() => handleCompanySelect(0)}
             >
-              모든 회사
+              모든 업체
             </SelectOption>
             {Array.isArray(companies) && companies.length === 0 ? (
               <SelectOption $isSelected={false} style={{ color: "#bdbdbd" }}>
-                등록된 회사가 없습니다
+                등록된 업체가 없습니다
               </SelectOption>
             ) : (
               (Array.isArray(companies) ? companies : []).map((company) => (
@@ -694,7 +702,7 @@ export default function MemberPage() {
             <TableRow>
               <TableHeader>이름</TableHeader>
               <TableHeader>아이디</TableHeader>
-              <TableHeader>회사</TableHeader>
+              <TableHeader>업체</TableHeader>
               <TableHeader>직책</TableHeader>
               <TableHeader>전화번호</TableHeader>
             </TableRow>

--- a/src/features/user/pages/MemberPage.tsx
+++ b/src/features/user/pages/MemberPage.tsx
@@ -969,32 +969,36 @@ export default function MemberPage() {
                       onClick={() => handleMemberClick(member)}
                     >
                       <FiCalendar size={14} style={{ color: "#8b5cf6" }} />
-                      <div style={{ display: "flex", flexDirection: "column" }}>
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "4px",
+                        }}
+                      >
                         <span style={{ fontSize: "14px", color: "#374151" }}>
                           {member.createdAt
                             ? new Date(member.createdAt).toLocaleDateString(
-                                "ko-KR"
-                              )
-                            : "N/A"}
-                          {member.createdAt && (
-                            <span
-                              style={{
-                                fontSize: "11px",
-                                color: "#9ca3af",
-                                marginLeft: "4px",
-                              }}
-                            >
-                              {new Date(member.createdAt).toLocaleTimeString(
                                 "ko-KR",
                                 {
-                                  hour: "2-digit",
-                                  minute: "2-digit",
-                                  hour12: true,
+                                  year: "numeric",
+                                  month: "2-digit",
+                                  day: "2-digit",
                                 }
-                              )}
-                            </span>
-                          )}
+                              )
+                            : "N/A"}
                         </span>
+                        {member.createdAt && (
+                          <span style={{ fontSize: "12px", color: "#6b7280" }}>
+                            {new Date(member.createdAt).toLocaleTimeString(
+                              "ko-KR",
+                              {
+                                hour: "2-digit",
+                                minute: "2-digit",
+                              }
+                            )}
+                          </span>
+                        )}
                       </div>
                     </div>
                   </TableCell>

--- a/src/features/user/pages/MemberPage.tsx
+++ b/src/features/user/pages/MemberPage.tsx
@@ -426,13 +426,13 @@ export default function MemberPage() {
 
   const fetchCompanies = async () => {
     try {
-      const response = await api.get("/api/companies/all"); // 충분한 크기로 모든 회사 데이터를 가져옴
+      const response = await api.get("/api/companies/all"); // 충분한 크기로 모든 업체 데이터를 가져옴
       setCompanies(Array.isArray(response.data.data) ? response.data.data : []);
       setCompanyError(null);
     } catch (err: unknown) {
-      setCompanies([]); // 회사가 없을 때도 빈 배열로
+      setCompanies([]); // 업체가 없을 때도 빈 배열로
       setCompanyError(
-        "회사를 불러오지 못했습니다. 회사가 등록되어 있지 않을 수 있습니다."
+        "업체를 불러오지 못했습니다. 업체가 등록되어 있지 않을 수 있습니다."
       );
       console.error("Failed to fetch companies:", err);
     }

--- a/src/features/user/pages/MemberPage.tsx
+++ b/src/features/user/pages/MemberPage.tsx
@@ -15,6 +15,7 @@ import {
   FiPhone,
   FiChevronLeft,
   FiChevronRight,
+  FiCalendar,
 } from "react-icons/fi";
 import { IoBusinessOutline, IoPeopleOutline } from "react-icons/io5";
 import { LuUserRoundCog } from "react-icons/lu";
@@ -29,6 +30,7 @@ export interface Member {
   phone: string;
   email: string;
   createdAt: string;
+  lastLoginAt?: string;
 }
 
 interface Company {
@@ -841,6 +843,7 @@ export default function MemberPage() {
               <TableHeader>업체</TableHeader>
               <TableHeader>직책</TableHeader>
               <TableHeader>연락처</TableHeader>
+              <TableHeader>가입일</TableHeader>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -877,7 +880,17 @@ export default function MemberPage() {
                         ({member.username})
                       </span>
                       <span style={{ fontSize: "12px", color: "#6b7280" }}>
-                        ({member.role === "ROLE_ADMIN" ? "관리자" : "사용자"})
+                        (
+                        {member.position === "admin"
+                          ? "관리자"
+                          : member.position === "developer" ||
+                            member.position === "개발자"
+                          ? "개발사 직원"
+                          : member.position === "client" ||
+                            member.position === "고객"
+                          ? "고객사 직원"
+                          : "사용자"}
+                        )
                       </span>
                     </div>
                   </TableCell>
@@ -887,7 +900,9 @@ export default function MemberPage() {
                         display: "flex",
                         alignItems: "center",
                         gap: "8px",
+                        cursor: "pointer",
                       }}
+                      onClick={() => handleMemberClick(member)}
                     >
                       <FiHome size={14} style={{ color: "#f59e0b" }} />
                       <span style={{ fontWeight: "500" }}>
@@ -904,9 +919,24 @@ export default function MemberPage() {
                         display: "flex",
                         alignItems: "center",
                         gap: "8px",
+                        cursor: "pointer",
                       }}
+                      onClick={() => handleMemberClick(member)}
                     >
-                      <FiUsers size={14} style={{ color: "#3b82f6" }} />
+                      {member.position === "admin" ? (
+                        <LuUserRoundCog
+                          size={14}
+                          style={{ color: "#8b5cf6" }}
+                        />
+                      ) : member.position === "developer" ||
+                        member.position === "개발자" ? (
+                        <FiUser size={14} style={{ color: "#3b82f6" }} />
+                      ) : member.position === "client" ||
+                        member.position === "고객" ? (
+                        <FiUser size={14} style={{ color: "#10b981" }} />
+                      ) : (
+                        <FiUser size={14} style={{ color: "#6b7280" }} />
+                      )}
                       <span style={{ fontWeight: "500" }}>
                         {member.position}
                       </span>
@@ -918,12 +948,54 @@ export default function MemberPage() {
                         display: "flex",
                         alignItems: "center",
                         gap: "8px",
+                        cursor: "pointer",
                       }}
+                      onClick={() => handleMemberClick(member)}
                     >
                       <FiPhone size={14} style={{ color: "#10b981" }} />
                       <span style={{ fontSize: "14px", color: "#374151" }}>
                         {formatTelNo(member.phone)}
                       </span>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "8px",
+                        cursor: "pointer",
+                      }}
+                      onClick={() => handleMemberClick(member)}
+                    >
+                      <FiCalendar size={14} style={{ color: "#8b5cf6" }} />
+                      <div style={{ display: "flex", flexDirection: "column" }}>
+                        <span style={{ fontSize: "14px", color: "#374151" }}>
+                          {member.createdAt
+                            ? new Date(member.createdAt).toLocaleDateString(
+                                "ko-KR"
+                              )
+                            : "N/A"}
+                          {member.createdAt && (
+                            <span
+                              style={{
+                                fontSize: "11px",
+                                color: "#9ca3af",
+                                marginLeft: "4px",
+                              }}
+                            >
+                              {new Date(member.createdAt).toLocaleTimeString(
+                                "ko-KR",
+                                {
+                                  hour: "2-digit",
+                                  minute: "2-digit",
+                                  hour12: true,
+                                }
+                              )}
+                            </span>
+                          )}
+                        </span>
+                      </div>
                     </div>
                   </TableCell>
                 </TableRow>

--- a/src/features/user/pages/profile/UserProfilePage.tsx
+++ b/src/features/user/pages/profile/UserProfilePage.tsx
@@ -35,14 +35,21 @@ export default function UserProfilePage() {
 
   if (!user) return <Container>불러오는 중...</Container>;
   const formatDate = (date: string) =>
-    new Intl.DateTimeFormat("ko-KR", { year: "numeric", month: "long", day: "numeric" }).format(new Date(date));
-
+    new Intl.DateTimeFormat("ko-KR", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    }).format(new Date(date));
 
   const formatDateTime = (date: string) => {
     const d = new Date(date);
     const kstDate = new Date(d.getTime() + 9 * 60 * 60 * 1000);
-    return `${kstDate.getFullYear()}년 ${kstDate.getMonth() + 1}월 ${kstDate.getDate()}일 `
-      + `${kstDate.getHours()}시 ${kstDate.getMinutes()}분`;
+    return (
+      `${kstDate.getFullYear()}년 ${
+        kstDate.getMonth() + 1
+      }월 ${kstDate.getDate()}일 ` +
+      `${kstDate.getHours()}시 ${kstDate.getMinutes()}분`
+    );
   };
 
   return (
@@ -54,7 +61,7 @@ export default function UserProfilePage() {
           </IconCircle>
           <div>
             <h3>내 정보</h3>
-            <span>개인 및 회사 정보</span>
+            <span>개인 및 업체 정보</span>
           </div>
         </CardHeader>
         <InfoGrid>
@@ -66,7 +73,7 @@ export default function UserProfilePage() {
           </InfoItem>
           <InfoItem>
             <Label>
-              <HiOfficeBuilding /> 회사
+              <HiOfficeBuilding /> 업체
             </Label>
             <Value>{user.companyName}</Value>
           </InfoItem>
@@ -89,7 +96,10 @@ export default function UserProfilePage() {
             <Value>{user.phone}</Value>
           </InfoItem>
           <div style={{ textAlign: "right" }}>
-            <EditButton type="button" onClick={() => setOpenChangePassword(true)}>
+            <EditButton
+              type="button"
+              onClick={() => setOpenChangePassword(true)}
+            >
               비밀번호 변경
             </EditButton>
           </div>
@@ -116,10 +126,15 @@ export default function UserProfilePage() {
           <Label>
             <FiLogIn /> 마지막 로그인
           </Label>
-          <Value>{user.lastLoginAt ? formatDateTime(user.lastLoginAt) : "정보 없음"}</Value>
+          <Value>
+            {user.lastLoginAt ? formatDateTime(user.lastLoginAt) : "정보 없음"}
+          </Value>
         </ActivityRow>
       </ActivityCard>
-      <ChangePasswordModal open={openChangePassword} onClose={() => setOpenChangePassword(false)} />
+      <ChangePasswordModal
+        open={openChangePassword}
+        onClose={() => setOpenChangePassword(false)}
+      />
     </Container>
   );
 }

--- a/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/layouts/Sidebar/Sidebar.tsx
@@ -66,9 +66,9 @@ export const Sidebar: React.FC = () => {
           <>
             <MenuItem
               icon={HiBuildingOffice2}
-              text="회사 관리"
+              text="업체 관리"
               isActive={location.pathname.startsWith("/company")}
-              onClick={() => handleMenuItemClick("회사 관리", "/company")}
+              onClick={() => handleMenuItemClick("업체 관리", "/company")}
             />
             <MenuItem
               icon={HiUsers}


### PR DESCRIPTION
## 📌 개요  
- 회원/업체 관리 페이지의 UI와 텍스트를 전체적으로 통일

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [x] 스타일 수정 (Style)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- 게시글 항목 간격 조정
- 업체관리, 회원관리 목록의 날짜 포맷 통일
- 업체관리 목록 노출 항목 및 UI 수정
- 상세정보(업체/회원)의 타이틀 및 설명 스타일 통일
- esc 키 입력 시 이력 상세 모달 닫히도록 수정
- 회원 목록에 가입일 항목 추가
- 회원 관리 탭의 전체 UI 정비
- 이력관리 회원 아이콘 교체
- '회사' → '업체' 용어 일괄 변경

## 🔍 관련 이슈
- Close #142

## 🧪 테스트 결과

## 👀 리뷰어에게 요청사항


## 📎 기타 참고 사항
