### PR TITLE
[Feature] 링크 첨부 기능 구현, 회원/업체 목록 ui 통일, 게시글/댓글 username 추가

### DIFF
--- a/src/components/ClickableMentionedUsername.tsx
+++ b/src/components/ClickableMentionedUsername.tsx
@@ -11,15 +11,16 @@ interface ClickableMentionedUsernameProps {
 
 const MentionedUsernameSpan = styled.span`
   color: #fdb924;
-  font-weight: 600;
+  font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease;
-  padding: 1px 3px;
-  border-radius: 3px;
-  margin: 0 1px;
+  padding: 0;
+  margin: 0;
+  display: inline;
+  position: relative;
 
   &:hover {
-    background-color: rgba(253, 185, 36, 0.1);
+    color: #f59e0b;
     text-decoration: underline;
   }
 

--- a/src/components/MentionSuggestions.tsx
+++ b/src/components/MentionSuggestions.tsx
@@ -11,11 +11,11 @@ interface MentionSuggestionsProps {
 }
 
 const SuggestionsContainer = styled.div<{
-  position: { top: number; left: number } | null;
+  $position: { top: number; left: number } | null;
 }>`
   position: absolute;
-  top: ${(props) => props.position?.top ?? 0}px;
-  left: ${(props) => props.position?.left ?? 0}px;
+  top: ${(props) => props.$position?.top ?? 0}px;
+  left: ${(props) => props.$position?.left ?? 0}px;
   background: white;
   border-radius: 8px;
   box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1),
@@ -115,7 +115,7 @@ const MentionSuggestions: React.FC<MentionSuggestionsProps> = ({
   }
 
   return (
-    <SuggestionsContainer position={position}>
+    <SuggestionsContainer $position={position}>
       {isLoading ? (
         <LoadingItem>
           <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>

--- a/src/components/MentionSuggestions.tsx
+++ b/src/components/MentionSuggestions.tsx
@@ -17,13 +17,12 @@ const SuggestionsContainer = styled.div<{
   top: ${(props) => props.position?.top ?? 0}px;
   left: ${(props) => props.position?.left ?? 0}px;
   background: white;
-  border: 1px solid #e5e7eb;
   border-radius: 8px;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
-    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1),
+    0 10px 10px -5px rgba(0, 0, 0, 0.04);
   max-height: 200px;
   overflow-y: auto;
-  z-index: 1000;
+  z-index: 9999;
   min-width: 200px;
   animation: slideIn 0.15s ease-out;
 
@@ -45,7 +44,7 @@ const SuggestionItem = styled.div.withConfig({
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 12px;
+  padding: 10px 12px;
   cursor: pointer;
   transition: all 0.15s ease;
   font-size: 14px;
@@ -86,19 +85,22 @@ const LoadingItem = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 12px;
+  padding: 16px;
   color: #6b7280;
   font-size: 14px;
+  font-weight: 500;
 `;
 
 const EmptyItem = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 12px;
+  padding: 16px;
   color: #6b7280;
   font-size: 14px;
   font-style: italic;
+  text-align: center;
+  line-height: 1.4;
 `;
 
 const MentionSuggestions: React.FC<MentionSuggestionsProps> = ({
@@ -108,16 +110,37 @@ const MentionSuggestions: React.FC<MentionSuggestionsProps> = ({
   onSelect,
   position,
 }) => {
-  if (!position || (!isLoading && suggestions.length === 0)) {
+  if (!position) {
     return null;
   }
 
   return (
     <SuggestionsContainer position={position}>
       {isLoading ? (
-        <LoadingItem>검색 중...</LoadingItem>
+        <LoadingItem>
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <div
+              style={{
+                width: "16px",
+                height: "16px",
+                border: "2px solid #fdb924",
+                borderTop: "2px solid transparent",
+                borderRadius: "50%",
+                animation: "spin 1s linear infinite",
+              }}
+            />
+            검색 중...
+          </div>
+        </LoadingItem>
       ) : suggestions.length === 0 ? (
-        <EmptyItem>검색 결과가 없습니다</EmptyItem>
+        <EmptyItem>
+          <div>
+            <div>검색 결과가 없습니다</div>
+            <div style={{ fontSize: "12px", marginTop: "4px" }}>
+              다른 키워드로 검색해보세요
+            </div>
+          </div>
+        </EmptyItem>
       ) : (
         suggestions.map((username, index) => (
           <SuggestionItem
@@ -133,6 +156,14 @@ const MentionSuggestions: React.FC<MentionSuggestionsProps> = ({
           </SuggestionItem>
         ))
       )}
+      <style>
+        {`
+          @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+          }
+        `}
+      </style>
     </SuggestionsContainer>
   );
 };

--- a/src/components/MentionTextArea.tsx
+++ b/src/components/MentionTextArea.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import styled from "styled-components";
 import { useMention } from "@/hooks/useMention";
 import MentionSuggestions from "./MentionSuggestions";
@@ -16,6 +16,7 @@ interface MentionTextAreaProps {
 const TextAreaContainer = styled.div`
   position: relative;
   width: 100%;
+  z-index: 1;
 `;
 
 const StyledTextArea = styled.textarea`
@@ -26,9 +27,12 @@ const StyledTextArea = styled.textarea`
   font-size: 0.875rem;
   background-color: white;
   color: #374151;
+  caret-color: #374151;
   resize: vertical;
   font-family: inherit;
   line-height: 1.5;
+  position: relative;
+  z-index: 2;
 
   &:focus {
     outline: none;
@@ -100,6 +104,16 @@ const MentionTextArea: React.FC<MentionTextAreaProps> = ({
     return { top, left };
   };
 
+  // mentionState가 변경될 때마다 위치 업데이트
+  useEffect(() => {
+    if (mentionState.isActive) {
+      const position = calculateCursorPosition();
+      setSuggestionPosition(position);
+    } else {
+      setSuggestionPosition(null);
+    }
+  }, [mentionState.isActive, mentionState.suggestions, value]);
+
   // 입력 변경 처리
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;
@@ -107,14 +121,6 @@ const MentionTextArea: React.FC<MentionTextAreaProps> = ({
 
     // @ 검색 처리
     handleInputChange(newValue, e.target.selectionStart);
-
-    // 제안 위치 업데이트
-    if (mentionState.isActive) {
-      const position = calculateCursorPosition();
-      setSuggestionPosition(position);
-    } else {
-      setSuggestionPosition(null);
-    }
   };
 
   // 제안 선택 처리
@@ -220,7 +226,6 @@ const MentionTextArea: React.FC<MentionTextAreaProps> = ({
         className={className}
         style={style}
       />
-
       <MentionSuggestions
         suggestions={mentionState.suggestions}
         selectedIndex={mentionState.selectedIndex}

--- a/src/components/MentionTextArea.tsx
+++ b/src/components/MentionTextArea.tsx
@@ -134,7 +134,10 @@ const MentionTextArea: React.FC<MentionTextAreaProps> = ({
       mentionState.endIndex
     );
 
-    onChange(newText);
+    // 멘션 선택 후 자동으로 스페이스바 공백 추가
+    const textWithSpace = newText + " ";
+
+    onChange(textWithSpace);
 
     // 멘션 상태 즉시 리셋
     setMentionState((prev) => ({
@@ -147,7 +150,7 @@ const MentionTextArea: React.FC<MentionTextAreaProps> = ({
     // 커서 위치 조정 - @username 뒤에 위치하도록
     setTimeout(() => {
       if (textareaRef.current) {
-        const newCursorPosition = mentionState.startIndex + username.length + 1; // @ 포함
+        const newCursorPosition = mentionState.startIndex + username.length + 2; // @ + username + space
         textareaRef.current.setSelectionRange(
           newCursorPosition,
           newCursorPosition

--- a/src/components/UserProfileDropdown.tsx
+++ b/src/components/UserProfileDropdown.tsx
@@ -24,11 +24,11 @@ const DropdownOverlay = styled.div`
 `;
 
 const DropdownContainer = styled.div<{
-  position: { top: number; left: number };
+  $position: { top: number; left: number };
 }>`
   position: absolute;
-  top: ${(props) => props.position.top}px;
-  left: ${(props) => props.position.left}px;
+  top: ${(props) => props.$position.top}px;
+  left: ${(props) => props.$position.left}px;
   background: white;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
@@ -217,7 +217,7 @@ const UserProfileDropdown: React.FC<UserProfileDropdownProps> = ({
   return (
     <>
       <DropdownOverlay />
-      <DropdownContainer ref={dropdownRef} position={position}>
+      <DropdownContainer ref={dropdownRef} $position={position}>
         <DropdownHeader>
           <UserInfo>
             <UserAvatar>{getInitials(username)}</UserAvatar>

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -638,6 +638,9 @@ export default function ActivityLogDetailModal({
       projectId: "프로젝트 ID",
       projectStepId: "프로젝트 단계 ID",
       files: "첨부파일",
+      links: "첨부 링크",
+      newLinks: "새로 추가된 링크",
+      linkIdsToDelete: "삭제된 링크 ID",
 
       // 프로젝트 관련 필드
       projectName: "프로젝트명",
@@ -802,6 +805,30 @@ export default function ActivityLogDetailModal({
         if (value.length === 0) {
           return "-";
         }
+
+        // 링크 배열 처리
+        if (fieldName === "links" || fieldName === "newLinks") {
+          if (value.length === 0) return "-";
+
+          // 링크 객체 배열인 경우 (기존 링크)
+          if (value[0] && typeof value[0] === "object" && "url" in value[0]) {
+            return value.map((link: any) => link.url).join(", ");
+          }
+
+          // 문자열 배열인 경우 (새 링크)
+          if (typeof value[0] === "string") {
+            return value.join(", ");
+          }
+
+          return value.join(", ");
+        }
+
+        // 링크 ID 배열 처리 (삭제된 링크)
+        if (fieldName === "linkIdsToDelete") {
+          if (value.length === 0) return "-";
+          return value.join(", ");
+        }
+
         // 배열의 첫 번째 파일 객체에서 fileName 추출
         const firstFile = value[0];
         if (
@@ -818,6 +845,12 @@ export default function ActivityLogDetailModal({
       if ("fileName" in value) {
         return (value as any).fileName || "-";
       }
+
+      // 단일 링크 객체 처리
+      if ("url" in value) {
+        return (value as any).url || "-";
+      }
+
       // 다른 객체 타입의 경우 JSON 문자열로 변환하지 않고 "-" 반환
       return "-";
     }

--- a/src/features/board/components/Answer/components/AnswerItem.tsx
+++ b/src/features/board/components/Answer/components/AnswerItem.tsx
@@ -112,10 +112,29 @@ const AnswerItem: React.FC<AnswerItemProps> = ({
       <AnswerMeta>
         <AnswerAuthor>
           <FaUser style={{ marginRight: "0.5rem" }} />
-          <AnswerAuthorName>
-            {answer.author?.name || "알 수 없는 사용자"}
-          </AnswerAuthorName>
-          <AnswerAuthorIp>{answer.authorIp}</AnswerAuthorIp>
+          {answer.author?.name || "알 수 없는 사용자"}
+          {answer.author?.username && (
+            <span
+              style={{
+                fontSize: "0.75rem",
+                color: "#6b7280",
+                marginLeft: "0.5rem",
+                fontWeight: "400",
+              }}
+            >
+              ({answer.author.username})
+            </span>
+          )}
+          <span
+            style={{
+              fontSize: "0.75rem",
+              color: "#6b7280",
+              marginLeft: "0.5rem",
+              fontWeight: "400",
+            }}
+          >
+            {answer.authorIp}
+          </span>
           {depth > 0 && <ReplyBadge>답글</ReplyBadge>}
           {answer.isBestAnswer && (
             <BestAnswerBadge>베스트 답변</BestAnswerBadge>

--- a/src/features/board/components/Answer/components/AnswerItem.tsx
+++ b/src/features/board/components/Answer/components/AnswerItem.tsx
@@ -16,6 +16,7 @@ import {
   ReplyBadge,
   BestAnswerBadge,
 } from "../styles/AnswerItem.styled";
+import ClickableUsername from "../../../../components/ClickableUsername";
 
 interface AnswerItemProps {
   answer: Answer;
@@ -112,25 +113,30 @@ const AnswerItem: React.FC<AnswerItemProps> = ({
       <AnswerMeta>
         <AnswerAuthor>
           <FaUser style={{ marginRight: "0.5rem" }} />
-          {answer.author?.name || "알 수 없는 사용자"}
-          {answer.author?.username && (
+          <ClickableUsername
+            username={answer.authorName || answer.author?.name || "undefined"}
+            userId={answer.author?.id || answer.authorId}
+            onClick={onUserProfileClick}
+            style={{ color: "#111827" }}
+          />
+          {answer.authorUsername && (
             <span
               style={{
-                fontSize: "0.75rem",
+                fontSize: 11,
                 color: "#6b7280",
-                marginLeft: "0.5rem",
-                fontWeight: "400",
+                marginLeft: 1,
+                fontWeight: 400,
               }}
             >
-              ({answer.author.username})
+              ({answer.authorUsername})
             </span>
           )}
           <span
             style={{
-              fontSize: "0.75rem",
-              color: "#6b7280",
-              marginLeft: "0.5rem",
-              fontWeight: "400",
+              fontSize: 11,
+              color: "#b0b0b0",
+              marginLeft: 6,
+              fontWeight: 400,
             }}
           >
             {answer.authorIp}

--- a/src/features/board/components/Answer/hooks/useAnswerUtils.tsx
+++ b/src/features/board/components/Answer/hooks/useAnswerUtils.tsx
@@ -26,7 +26,13 @@ export const formatAnswerContent = (
         );
       } else {
         return (
-          <span key={index} style={{ color: "#fdb924", fontWeight: "600" }}>
+          <span
+            key={index}
+            style={{
+              color: "#fdb924",
+              fontWeight: "500",
+            }}
+          >
             {part}
           </span>
         );

--- a/src/features/board/components/Answer/pages/AnswerDetailModal.tsx
+++ b/src/features/board/components/Answer/pages/AnswerDetailModal.tsx
@@ -29,6 +29,7 @@ import type { Answer } from "@/features/project-d/types/question";
 import { useAuth } from "@/hooks/useAuth";
 import MentionTextArea from "@/components/MentionTextArea";
 import ClickableMentionedUsername from "@/components/ClickableMentionedUsername";
+import ClickableUsername from "@/components/ClickableUsername";
 
 interface AnswerDetailModalProps {
   open: boolean;
@@ -327,25 +328,32 @@ const AnswerDetailModal: React.FC<AnswerDetailModalProps> = ({
                     }}
                   >
                     <FaUser style={{ marginRight: "0.5rem" }} />
-                    {answer.author?.name || "알 수 없는 사용자"}
-                    {answer.author?.username && (
+                    <ClickableUsername
+                      username={
+                        answer.authorName || answer.author?.name || "undefined"
+                      }
+                      userId={answer.author?.id || answer.authorId}
+                      onClick={onUserProfileClick}
+                      style={{ color: "#111827" }}
+                    />
+                    {answer.authorUsername && (
                       <span
                         style={{
-                          fontSize: "0.75rem",
+                          fontSize: 11,
                           color: "#6b7280",
-                          marginLeft: "0.5rem",
-                          fontWeight: "400",
+                          marginLeft: 1,
+                          fontWeight: 400,
                         }}
                       >
-                        ({answer.author.username})
+                        ({answer.authorUsername})
                       </span>
                     )}
                     <span
                       style={{
-                        fontSize: "0.75rem",
-                        color: "#6b7280",
-                        marginLeft: "0.5rem",
-                        fontWeight: "400",
+                        fontSize: 11,
+                        color: "#b0b0b0",
+                        marginLeft: 6,
+                        fontWeight: 400,
                       }}
                     >
                       {answer.authorIp}

--- a/src/features/board/components/Answer/pages/AnswerDetailModal.tsx
+++ b/src/features/board/components/Answer/pages/AnswerDetailModal.tsx
@@ -328,6 +328,18 @@ const AnswerDetailModal: React.FC<AnswerDetailModalProps> = ({
                   >
                     <FaUser style={{ marginRight: "0.5rem" }} />
                     {answer.author?.name || "알 수 없는 사용자"}
+                    {answer.author?.username && (
+                      <span
+                        style={{
+                          fontSize: "0.75rem",
+                          color: "#6b7280",
+                          marginLeft: "0.5rem",
+                          fontWeight: "400",
+                        }}
+                      >
+                        ({answer.author.username})
+                      </span>
+                    )}
                     <span
                       style={{
                         fontSize: "0.75rem",

--- a/src/features/board/components/Comment/hooks/useCommentUtils.tsx
+++ b/src/features/board/components/Comment/hooks/useCommentUtils.tsx
@@ -5,11 +5,7 @@ import ClickableMentionedUsername from "@/components/ClickableMentionedUsername"
 
 const MentionSpan = styled.span`
   color: #fdb924;
-  font-weight: 600;
-  background-color: rgba(253, 185, 36, 0.1);
-  padding: 2px 4px;
-  border-radius: 4px;
-  margin: 0 1px;
+  font-weight: 500;
 `;
 
 // 날짜 포맷팅 함수

--- a/src/features/board/components/Post/components/DetailModal/CommentForm.tsx
+++ b/src/features/board/components/Post/components/DetailModal/CommentForm.tsx
@@ -19,7 +19,7 @@ const CommentForm: React.FC<CommentFormProps> = ({
   onChange,
   onSubmit,
   disabled = false,
-  placeholder = "댓글을 입력하세요. @를 입력하여 사용자를 언급할 수 있습니다. (우측 하단 마우스 드래그를 통해 크기 조절 가능)",
+  placeholder = "댓글을 입력하세요. @를 입력하여 사용자를 언급할 수 있습니다.",
   buttonText = "댓글",
 }) => {
   return (

--- a/src/features/board/components/Post/components/DetailModal/CommentItem.tsx
+++ b/src/features/board/components/Post/components/DetailModal/CommentItem.tsx
@@ -72,21 +72,21 @@ const CommentItem: React.FC<CommentItemProps> = ({
       <CommentMeta>
         <CommentAuthor>
           <ClickableUsername
-            username={comment.author?.name || comment.authorName || "undefined"}
+            username={comment.authorName || comment.author?.name || "undefined"}
             userId={comment.author?.id || comment.authorId}
             onClick={onUserProfileClick}
             style={{ color: "#111827" }}
           />
-          {comment.author?.username && (
+          {comment.authorUsername && (
             <span
               style={{
                 fontSize: 11,
                 color: "#6b7280",
-                marginLeft: 4,
+                marginLeft: -3,
                 fontWeight: 400,
               }}
             >
-              ({comment.author.username})
+              ({comment.authorUsername})
             </span>
           )}
           <span

--- a/src/features/board/components/Post/components/DetailModal/CommentItem.tsx
+++ b/src/features/board/components/Post/components/DetailModal/CommentItem.tsx
@@ -77,6 +77,18 @@ const CommentItem: React.FC<CommentItemProps> = ({
             onClick={onUserProfileClick}
             style={{ color: "#111827" }}
           />
+          {comment.author?.username && (
+            <span
+              style={{
+                fontSize: 11,
+                color: "#6b7280",
+                marginLeft: 4,
+                fontWeight: 400,
+              }}
+            >
+              ({comment.author.username})
+            </span>
+          )}
           <span
             style={{
               fontSize: 11,

--- a/src/features/board/components/Post/components/DetailModal/CommentItem.tsx
+++ b/src/features/board/components/Post/components/DetailModal/CommentItem.tsx
@@ -152,19 +152,23 @@ const CommentItem: React.FC<CommentItemProps> = ({
             </div>
           </div>
         ) : (
-          comment.content
-            .split(/(@\S+)/g)
-            .map((part, idx) =>
-              part.startsWith("@") ? (
-                <ClickableMentionedUsername
-                  key={idx}
-                  username={part.substring(1)}
-                  onClick={onUserProfileClick}
-                />
-              ) : (
-                <span key={idx}>{part}</span>
-              )
+          comment.content.split(/(@\S+)/g).map((part, idx) =>
+            part.startsWith("@") ? (
+              <span
+                key={idx}
+                style={{
+                  color: "#fdb924",
+                  fontWeight: "500",
+                  cursor: "pointer",
+                }}
+                onClick={(e) => onUserProfileClick(e, part.substring(1))}
+              >
+                {part}
+              </span>
+            ) : (
+              <span key={idx}>{part}</span>
             )
+          )
         )}
       </CommentText>
     </StyledCommentItem>

--- a/src/features/board/components/Post/components/DetailModal/PostHeader.tsx
+++ b/src/features/board/components/Post/components/DetailModal/PostHeader.tsx
@@ -225,11 +225,23 @@ const PostHeader: React.FC<PostHeaderProps> = ({
             onClick={onUserProfileClick}
             style={{ color: "#111827" }}
           />
+          {post.authorUsername && (
+            <span
+              style={{
+                fontSize: 12,
+                color: "#6b7280",
+                marginLeft: -9,
+                fontWeight: 400,
+              }}
+            >
+              ({post.authorUsername})
+            </span>
+          )}
           <span
             style={{
               fontSize: 12,
               color: "#b0b0b0",
-              marginLeft: 8,
+              marginLeft: 1,
               fontWeight: 400,
             }}
           >

--- a/src/features/board/components/Post/components/DetailModal/PostLinks.tsx
+++ b/src/features/board/components/Post/components/DetailModal/PostLinks.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { FiExternalLink } from "react-icons/fi";
+import { TbWorldShare } from "react-icons/tb";
+import {
+  AttachmentsSection,
+  FileList,
+  FileItem,
+  FileInfo,
+  FileIcon,
+  FileDetails,
+  FileName,
+  FileMeta,
+  NoFilesMessage,
+} from "@/features/board/components/Post/styles/ProjectPostDetailModal.styled";
+
+interface PostLink {
+  id: number;
+  url: string;
+}
+
+interface PostLinksProps {
+  links: PostLink[];
+}
+
+const PostLinks: React.FC<PostLinksProps> = ({ links }) => {
+  if (!links || links.length === 0) {
+    return (
+      <AttachmentsSection>
+        <div style={{ fontSize: 15, fontWeight: 600, marginBottom: 10 }}>
+          첨부 링크
+        </div>
+        <FileList>
+          <FileItem>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+                padding: "2px 12px",
+              }}
+            >
+              <TbWorldShare
+                size={16}
+                style={{ color: "#9ca3af", marginLeft: -10 }}
+              />
+              <NoFilesMessage>첨부된 링크가 없습니다.</NoFilesMessage>
+            </div>
+          </FileItem>
+        </FileList>
+      </AttachmentsSection>
+    );
+  }
+
+  return (
+    <AttachmentsSection>
+      <div style={{ fontSize: 15, fontWeight: 600, marginBottom: 10 }}>
+        첨부 링크
+      </div>
+      <FileList>
+        {links.map((link) => (
+          <FileItem key={link.id}>
+            <FileInfo>
+              <FileIcon>
+                <TbWorldShare size={16} style={{ color: "#8b5cf6" }} />
+              </FileIcon>
+              <FileDetails>
+                <FileName>
+                  <a
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      color: "#2563eb",
+                      textDecoration: "none",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "4px",
+                    }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.textDecoration = "underline";
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.textDecoration = "none";
+                    }}
+                  >
+                    {link.url}
+                    <FiExternalLink size={12} />
+                  </a>
+                </FileName>
+                <FileMeta>
+                  <span></span>
+                </FileMeta>
+              </FileDetails>
+            </FileInfo>
+          </FileItem>
+        ))}
+      </FileList>
+    </AttachmentsSection>
+  );
+};
+
+export default PostLinks;

--- a/src/features/board/components/Post/components/DetailModal/ProjectPostDetailModal.tsx
+++ b/src/features/board/components/Post/components/DetailModal/ProjectPostDetailModal.tsx
@@ -35,6 +35,7 @@ import { FiX } from "react-icons/fi";
 import PostHeader from "./PostHeader";
 import PostContent from "./PostContent";
 import PostAttachments from "./PostAttachments";
+import PostLinks from "./PostLinks";
 import CommentSection from "./CommentSection";
 
 interface PostDetailModalProps {
@@ -446,40 +447,7 @@ const PostDetailModal: React.FC<PostDetailModalProps> = ({
                   onFileDownload={handleFileDownload}
                   postId={post.postId}
                 />
-                {post.links && post.links.length > 0 && (
-                  <div style={{ margin: "16px 0" }}>
-                    <h4
-                      style={{
-                        fontSize: "15px",
-                        fontWeight: 600,
-                        marginBottom: "6px",
-                      }}
-                    >
-                      첨부 링크
-                    </h4>
-                    <ul style={{ paddingLeft: 0, margin: 0 }}>
-                      {post.links.map((link) => (
-                        <li
-                          key={link.id}
-                          style={{ listStyle: "none", marginBottom: "4px" }}
-                        >
-                          <a
-                            href={link.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{
-                              color: "#2563eb",
-                              textDecoration: "underline",
-                              wordBreak: "break-all",
-                            }}
-                          >
-                            {link.url}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
+                <PostLinks links={post.links} />
                 <CommentSection
                   comments={comments}
                   commentText={commentText}

--- a/src/features/board/components/Post/components/DetailModal/ProjectPostDetailModal.tsx
+++ b/src/features/board/components/Post/components/DetailModal/ProjectPostDetailModal.tsx
@@ -446,6 +446,40 @@ const PostDetailModal: React.FC<PostDetailModalProps> = ({
                   onFileDownload={handleFileDownload}
                   postId={post.postId}
                 />
+                {post.links && post.links.length > 0 && (
+                  <div style={{ margin: "16px 0" }}>
+                    <h4
+                      style={{
+                        fontSize: "15px",
+                        fontWeight: 600,
+                        marginBottom: "6px",
+                      }}
+                    >
+                      첨부 링크
+                    </h4>
+                    <ul style={{ paddingLeft: 0, margin: 0 }}>
+                      {post.links.map((link) => (
+                        <li
+                          key={link.id}
+                          style={{ listStyle: "none", marginBottom: "4px" }}
+                        >
+                          <a
+                            href={link.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{
+                              color: "#2563eb",
+                              textDecoration: "underline",
+                              wordBreak: "break-all",
+                            }}
+                          >
+                            {link.url}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
                 <CommentSection
                   comments={comments}
                   commentText={commentText}

--- a/src/features/board/components/Post/components/DetailModal/ReplyItem.tsx
+++ b/src/features/board/components/Post/components/DetailModal/ReplyItem.tsx
@@ -71,21 +71,21 @@ const ReplyItem: React.FC<ReplyItemProps> = ({
       <CommentMeta>
         <CommentAuthor>
           <ClickableUsername
-            username={reply.author?.name || reply.authorName || "undefined"}
+            username={reply.authorName || reply.author?.name || "undefined"}
             userId={reply.author?.id || reply.authorId}
             onClick={onUserProfileClick}
             style={{ color: "#111827" }}
           />
-          {reply.author?.username && (
+          {reply.authorUsername && (
             <span
               style={{
                 fontSize: 11,
                 color: "#6b7280",
-                marginLeft: 4,
+                marginLeft: -3,
                 fontWeight: 400,
               }}
             >
-              ({reply.author.username})
+              ({reply.authorUsername})
             </span>
           )}
           <span

--- a/src/features/board/components/Post/components/DetailModal/ReplyItem.tsx
+++ b/src/features/board/components/Post/components/DetailModal/ReplyItem.tsx
@@ -165,19 +165,23 @@ const ReplyItem: React.FC<ReplyItemProps> = ({
             </div>
           </div>
         ) : (
-          reply.content
-            .split(/(@\S+)/g)
-            .map((part, idx) =>
-              part.startsWith("@") ? (
-                <ClickableMentionedUsername
-                  key={idx}
-                  username={part.substring(1)}
-                  onClick={onUserProfileClick}
-                />
-              ) : (
-                <span key={idx}>{part}</span>
-              )
+          reply.content.split(/(@\S+)/g).map((part, idx) =>
+            part.startsWith("@") ? (
+              <span
+                key={idx}
+                style={{
+                  color: "#fdb924",
+                  fontWeight: "500",
+                  cursor: "pointer",
+                }}
+                onClick={(e) => onUserProfileClick(e, part.substring(1))}
+              >
+                {part}
+              </span>
+            ) : (
+              <span key={idx}>{part}</span>
             )
+          )
         )}
       </CommentText>
     </StyledCommentItem>

--- a/src/features/board/components/Post/components/DetailModal/ReplyItem.tsx
+++ b/src/features/board/components/Post/components/DetailModal/ReplyItem.tsx
@@ -76,6 +76,18 @@ const ReplyItem: React.FC<ReplyItemProps> = ({
             onClick={onUserProfileClick}
             style={{ color: "#111827" }}
           />
+          {reply.author?.username && (
+            <span
+              style={{
+                fontSize: 11,
+                color: "#6b7280",
+                marginLeft: 4,
+                fontWeight: 400,
+              }}
+            >
+              ({reply.author.username})
+            </span>
+          )}
           <span
             style={{
               fontSize: 11,

--- a/src/features/board/components/Post/components/FormModal/FullScreenContentEditor.tsx
+++ b/src/features/board/components/Post/components/FormModal/FullScreenContentEditor.tsx
@@ -328,7 +328,7 @@ const FullScreenContentEditor: React.FC<FullScreenContentEditorProps> = ({
                 onChange={(e) => setContent(e.target.value)}
                 placeholder={
                   isMarkdownMode
-                    ? "마크다운 문법을 사용하여 내용을 작성할 수 있습니다."
+                    ? "마크다운 문법을 사용하여 내용을 작성하세요."
                     : "게시글 내용을 입력하세요."
                 }
                 style={{

--- a/src/features/board/components/Post/components/FormModal/PostFormModal.tsx
+++ b/src/features/board/components/Post/components/FormModal/PostFormModal.tsx
@@ -538,7 +538,7 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
       case "COMPLETED":
         return "완료";
       case "PENDING":
-        return "대기";
+        return "";
       default:
         return status;
     }

--- a/src/features/board/components/Post/components/FormModal/PostFormModal.tsx
+++ b/src/features/board/components/Post/components/FormModal/PostFormModal.tsx
@@ -397,12 +397,6 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
           ...(newLinks.length > 0 && { newLinks }),
         };
 
-        console.log("=== 게시글 수정 요청 데이터 ===");
-        console.log("deletedLinkIds:", deletedLinkIds);
-        console.log("newLinks:", newLinks);
-        console.log("requestData:", requestData);
-        console.log("================================");
-
         // 수정 전 기존 게시글 정보 저장 (단계 변경 확인용)
         const originalPost = await getPostDetail(postId);
         const originalStepId = originalPost.data?.stepId;

--- a/src/features/board/components/Post/components/FormModal/PostFormModal.tsx
+++ b/src/features/board/components/Post/components/FormModal/PostFormModal.tsx
@@ -397,6 +397,12 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
           ...(newLinks.length > 0 && { newLinks }),
         };
 
+        console.log("=== 게시글 수정 요청 데이터 ===");
+        console.log("deletedLinkIds:", deletedLinkIds);
+        console.log("newLinks:", newLinks);
+        console.log("requestData:", requestData);
+        console.log("================================");
+
         // 수정 전 기존 게시글 정보 저장 (단계 변경 확인용)
         const originalPost = await getPostDetail(postId);
         const originalStepId = originalPost.data?.stepId;

--- a/src/features/board/components/Post/components/FormModal/PostFormModal.tsx
+++ b/src/features/board/components/Post/components/FormModal/PostFormModal.tsx
@@ -57,6 +57,7 @@ import {
   showSuccessToast,
   withErrorHandling,
 } from "@/utils/errorHandler";
+import LinkInputSection from "./components/LinkInputSection";
 
 interface PostFormModalProps {
   open: boolean;
@@ -101,6 +102,13 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
   // 기존 파일 관련 상태 (수정 모드용)
   const [existingFiles, setExistingFiles] = useState<PostFile[]>([]);
   const [deletedFileIds, setDeletedFileIds] = useState<number[]>([]);
+
+  // 링크 관련 상태
+  const [existingLinks, setExistingLinks] = useState<
+    { id: number; url: string }[]
+  >([]);
+  const [newLinks, setNewLinks] = useState<string[]>([]);
+  const [deletedLinkIds, setDeletedLinkIds] = useState<number[]>([]);
 
   // 드롭다운 상태
   const [isTypeDropdownOpen, setIsTypeDropdownOpen] = useState(false);
@@ -183,6 +191,10 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
             // 기존 파일 정보 설정
             setExistingFiles(post.files || []);
             setDeletedFileIds([]);
+            // 기존 링크 정보 설정
+            setExistingLinks(post.links || []);
+            setNewLinks([]);
+            setDeletedLinkIds([]);
           }
           return response;
         }, "게시글을 불러오는데 실패했습니다.");
@@ -242,6 +254,10 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
       // 생성 모드에서는 기존 파일 초기화
       setExistingFiles([]);
       setDeletedFileIds([]);
+      // 생성 모드에서는 기존 링크 초기화
+      setExistingLinks([]);
+      setNewLinks([]);
+      setDeletedLinkIds([]);
     }
   }, [open, mode, postId, parentId, stepId, projectId]);
 
@@ -347,6 +363,7 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
         const requestData = {
           ...formData,
           ...(parentId && { parentId }),
+          ...(newLinks.length > 0 && { newLinks }),
         };
 
         const response = await createPost(requestData, files);
@@ -355,6 +372,9 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
           setFiles([]);
           setExistingFiles([]);
           setDeletedFileIds([]);
+          setExistingLinks([]);
+          setNewLinks([]);
+          setDeletedLinkIds([]);
           setIsDragOver(false);
           showSuccessToast("게시글이 성공적으로 생성되었습니다.");
           onSuccess?.();
@@ -373,6 +393,8 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
           priority: formData.priority,
           stepId: formData.stepId,
           ...(deletedFileIds.length > 0 && { fileIdsToDelete: deletedFileIds }),
+          ...(deletedLinkIds.length > 0 && { linkIdsToDelete: deletedLinkIds }),
+          ...(newLinks.length > 0 && { newLinks }),
         };
 
         // 수정 전 기존 게시글 정보 저장 (단계 변경 확인용)
@@ -385,6 +407,9 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
           setFiles([]);
           setExistingFiles([]);
           setDeletedFileIds([]);
+          setExistingLinks([]);
+          setNewLinks([]);
+          setDeletedLinkIds([]);
           setIsDragOver(false);
 
           // 단계가 변경된 경우 특별한 메시지 표시
@@ -437,6 +462,9 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
     setFiles([]);
     setExistingFiles([]);
     setDeletedFileIds([]);
+    setExistingLinks([]);
+    setNewLinks([]);
+    setDeletedLinkIds([]);
     setFormErrors({});
     setError(null);
     onClose();
@@ -920,6 +948,16 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
                     handleFileRemove={handleFileRemove}
                     handleExistingFileRemove={handleExistingFileRemove}
                     colorTheme={colorTheme}
+                  />
+
+                  <LinkInputSection
+                    mode={mode}
+                    existingLinks={existingLinks}
+                    setExistingLinks={setExistingLinks}
+                    newLinks={newLinks}
+                    setNewLinks={setNewLinks}
+                    deletedLinkIds={deletedLinkIds}
+                    setDeletedLinkIds={setDeletedLinkIds}
                   />
 
                   {error && <ErrorMessage>{error}</ErrorMessage>}

--- a/src/features/board/components/Post/components/FormModal/components/ContentEditorSection.tsx
+++ b/src/features/board/components/Post/components/FormModal/components/ContentEditorSection.tsx
@@ -305,7 +305,7 @@ const ContentEditorSection: React.FC<ContentEditorSectionProps> = ({
           onChange={handleContentChange}
           placeholder={
             isMarkdownMode
-              ? "마크다운 문법을 사용하여 내용을 작성할 수 있습니다. @를 입력하여 사용자를 언급할 수 있습니다."
+              ? "마크다운 문법을 사용하여 내용을 작성하세요. @를 입력하여 사용자를 언급할 수 있습니다."
               : "게시글 내용을 입력하세요. @를 입력하여 사용자를 언급할 수 있습니다."
           }
           rows={8}

--- a/src/features/board/components/Post/components/FormModal/components/LinkInputSection.tsx
+++ b/src/features/board/components/Post/components/FormModal/components/LinkInputSection.tsx
@@ -53,8 +53,15 @@ const LinkInputSection: React.FC<LinkInputSectionProps> = ({
 
   // 기존 링크 삭제
   const handleRemoveExistingLink = (id: number) => {
+    console.log("=== 기존 링크 삭제 ===");
+    console.log("삭제할 링크 ID:", id);
+    console.log("삭제 전 deletedLinkIds:", deletedLinkIds);
+
     setDeletedLinkIds([...deletedLinkIds, id]);
     setExistingLinks(existingLinks.filter((l) => l.id !== id));
+
+    console.log("삭제 후 deletedLinkIds:", [...deletedLinkIds, id]);
+    console.log("=========================");
   };
 
   return (

--- a/src/features/board/components/Post/components/FormModal/components/LinkInputSection.tsx
+++ b/src/features/board/components/Post/components/FormModal/components/LinkInputSection.tsx
@@ -53,15 +53,8 @@ const LinkInputSection: React.FC<LinkInputSectionProps> = ({
 
   // 기존 링크 삭제
   const handleRemoveExistingLink = (id: number) => {
-    console.log("=== 기존 링크 삭제 ===");
-    console.log("삭제할 링크 ID:", id);
-    console.log("삭제 전 deletedLinkIds:", deletedLinkIds);
-
     setDeletedLinkIds([...deletedLinkIds, id]);
     setExistingLinks(existingLinks.filter((l) => l.id !== id));
-
-    console.log("삭제 후 deletedLinkIds:", [...deletedLinkIds, id]);
-    console.log("=========================");
   };
 
   return (

--- a/src/features/board/components/Post/components/FormModal/components/LinkInputSection.tsx
+++ b/src/features/board/components/Post/components/FormModal/components/LinkInputSection.tsx
@@ -1,0 +1,205 @@
+import React, { useState } from "react";
+import {
+  FormGroup,
+  Label,
+  Input,
+} from "@/features/board/components/Post/styles/PostFormModal.styled";
+import { FiLink, FiTrash2, FiPlus } from "react-icons/fi";
+
+interface LinkInputSectionProps {
+  mode: "create" | "edit";
+  existingLinks: { id: number; url: string }[];
+  setExistingLinks: (links: { id: number; url: string }[]) => void;
+  newLinks: string[];
+  setNewLinks: (links: string[]) => void;
+  deletedLinkIds: number[];
+  setDeletedLinkIds: (ids: number[]) => void;
+}
+
+const LinkInputSection: React.FC<LinkInputSectionProps> = ({
+  mode,
+  existingLinks,
+  setExistingLinks,
+  newLinks,
+  setNewLinks,
+  deletedLinkIds,
+  setDeletedLinkIds,
+}) => {
+  const [linkInput, setLinkInput] = useState("");
+
+  // 새 링크 추가
+  const handleAddLink = () => {
+    if (linkInput.trim() && !newLinks.includes(linkInput.trim())) {
+      setNewLinks([...newLinks, linkInput.trim()]);
+      setLinkInput("");
+    }
+  };
+
+  // 새 링크 삭제
+  const handleRemoveNewLink = (idx: number) => {
+    setNewLinks(newLinks.filter((_, i) => i !== idx));
+  };
+
+  // 기존 링크 삭제
+  const handleRemoveExistingLink = (id: number) => {
+    setDeletedLinkIds([...deletedLinkIds, id]);
+    setExistingLinks(existingLinks.filter((l) => l.id !== id));
+  };
+
+  return (
+    <FormGroup>
+      <Label>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <FiLink size={16} style={{ color: "#8b5cf6" }} />
+          첨부 링크
+        </div>
+      </Label>
+      {/* 기존 링크 목록 (수정 모드) */}
+      {mode === "edit" && existingLinks.length > 0 && (
+        <div style={{ marginBottom: 8 }}>
+          <div
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              color: "#374151",
+              marginBottom: 4,
+            }}
+          >
+            기존 링크
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {existingLinks.map((link) => (
+              <div
+                key={link.id}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  background: "#f9fafb",
+                  borderRadius: 6,
+                  border: "1px solid #e5e7eb",
+                  padding: "6px 10px",
+                }}
+              >
+                <a
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    color: "#2563eb",
+                    textDecoration: "underline",
+                    flex: 1,
+                    wordBreak: "break-all",
+                  }}
+                >
+                  {link.url}
+                </a>
+                <button
+                  type="button"
+                  onClick={() => handleRemoveExistingLink(link.id)}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    marginLeft: 8,
+                    color: "#ef4444",
+                    cursor: "pointer",
+                  }}
+                >
+                  <FiTrash2 size={16} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {/* 새로 추가할 링크 목록 */}
+      {newLinks.length > 0 && (
+        <div style={{ marginBottom: 8 }}>
+          <div
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              color: "#374151",
+              marginBottom: 4,
+            }}
+          >
+            새로 추가할 링크
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {newLinks.map((url, idx) => (
+              <div
+                key={url + idx}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  background: "#f9fafb",
+                  borderRadius: 6,
+                  border: "1px solid #e5e7eb",
+                  padding: "6px 10px",
+                }}
+              >
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    color: "#2563eb",
+                    textDecoration: "underline",
+                    flex: 1,
+                    wordBreak: "break-all",
+                  }}
+                >
+                  {url}
+                </a>
+                <button
+                  type="button"
+                  onClick={() => handleRemoveNewLink(idx)}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    marginLeft: 8,
+                    color: "#ef4444",
+                    cursor: "pointer",
+                  }}
+                >
+                  <FiTrash2 size={16} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {/* 새 링크 입력란 */}
+      <div style={{ display: "flex", gap: 8 }}>
+        <Input
+          type="url"
+          placeholder="https://example.com/"
+          value={linkInput}
+          onChange={(e) => setLinkInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleAddLink();
+          }}
+        />
+        <button
+          type="button"
+          onClick={handleAddLink}
+          style={{
+            background: "#fdb924",
+            border: "none",
+            borderRadius: 6,
+            color: "#fff",
+            fontWeight: 600,
+            padding: "0 14px",
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            cursor: "pointer",
+          }}
+        >
+          <FiPlus size={16} /> 추가
+        </button>
+      </div>
+    </FormGroup>
+  );
+};
+
+export default LinkInputSection;

--- a/src/features/board/components/Post/components/FormModal/components/LinkInputSection.tsx
+++ b/src/features/board/components/Post/components/FormModal/components/LinkInputSection.tsx
@@ -29,8 +29,19 @@ const LinkInputSection: React.FC<LinkInputSectionProps> = ({
 
   // 새 링크 추가
   const handleAddLink = () => {
-    if (linkInput.trim() && !newLinks.includes(linkInput.trim())) {
-      setNewLinks([...newLinks, linkInput.trim()]);
+    const trimmedUrl = linkInput.trim();
+    if (trimmedUrl) {
+      // URL 형식 검증 (http:// 또는 https://로 시작하는지 확인)
+      if (
+        !trimmedUrl.startsWith("http://") &&
+        !trimmedUrl.startsWith("https://")
+      ) {
+        alert("올바른 URL 형식으로 입력해주세요. (예: https://example.com)");
+        return;
+      }
+
+      // 중복 체크 제거 - 같은 URL이라도 여러 번 추가 가능하도록
+      setNewLinks([...newLinks, trimmedUrl]);
       setLinkInput("");
     }
   };
@@ -63,9 +74,12 @@ const LinkInputSection: React.FC<LinkInputSectionProps> = ({
               fontWeight: 600,
               color: "#374151",
               marginBottom: 4,
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
             }}
           >
-            기존 링크
+            기존 링크 ({existingLinks.length}개)
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
             {existingLinks.map((link) => (
@@ -120,9 +134,12 @@ const LinkInputSection: React.FC<LinkInputSectionProps> = ({
               fontWeight: 600,
               color: "#374151",
               marginBottom: 4,
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
             }}
           >
-            새로 추가할 링크
+            새로 추가할 링크 ({newLinks.length}개)
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
             {newLinks.map((url, idx) => (
@@ -172,16 +189,20 @@ const LinkInputSection: React.FC<LinkInputSectionProps> = ({
       <div style={{ display: "flex", gap: 8 }}>
         <Input
           type="url"
-          placeholder="https://example.com/"
+          placeholder="https://example.com (여러 개 추가 가능)"
           value={linkInput}
           onChange={(e) => setLinkInput(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter") handleAddLink();
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleAddLink();
+            }
           }}
         />
         <button
           type="button"
           onClick={handleAddLink}
+          title="링크 추가 (여러 개 추가 가능)"
           style={{
             background: "#fdb924",
             border: "none",
@@ -193,6 +214,13 @@ const LinkInputSection: React.FC<LinkInputSectionProps> = ({
             alignItems: "center",
             gap: 4,
             cursor: "pointer",
+            transition: "background-color 0.2s ease",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = "#f59e0b";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = "#fdb924";
           }}
         >
           <FiPlus size={16} /> 추가

--- a/src/features/board/components/Post/components/FormModal/components/PostFormFields.tsx
+++ b/src/features/board/components/Post/components/FormModal/components/PostFormFields.tsx
@@ -133,7 +133,7 @@ const PostFormFields: React.FC<PostFormFieldsProps> = ({
             name="content"
             value={formData.content}
             onChange={handleContentChange}
-            placeholder="게시글 내용을 입력하세요. @를 입력하여 사용자를 언급할 수 있습니다. (크기 조절 가능)"
+            placeholder="게시글 내용을 입력하세요. @를 입력하여 사용자를 언급할 수 있습니다."
             rows={8}
           />
           <ResizeGuide>

--- a/src/features/board/components/Post/pages/PostListPage.tsx
+++ b/src/features/board/components/Post/pages/PostListPage.tsx
@@ -132,7 +132,6 @@ const getPriorityStyle = (priority: number) => {
 };
 
 export default function PostListPage() {
-  const { stepId } = useParams();
   const [searchParams] = useSearchParams();
   const stepName = searchParams.get("stepName") || "알 수 없는 단계";
   const [posts, setPosts] = useState<Post[]>([]);
@@ -547,7 +546,9 @@ export default function PostListPage() {
           <FilterGroup>
             <FilterLabel>단계</FilterLabel>
             <FilterSelect
-              value={stepFilter ?? ""}
+              value={
+                stepFilter !== null ? stepFilter : projectSteps[0]?.id || ""
+              }
               onChange={(e) => setStepFilter(Number(e.target.value))}
               style={{ minWidth: 120 }}
             >

--- a/src/features/board/components/Post/pages/PostListPage.tsx
+++ b/src/features/board/components/Post/pages/PostListPage.tsx
@@ -647,7 +647,20 @@ export default function PostListPage() {
                             ) : null}
                           </div>
                         </TableCell>
-                        <TableCell>{post.author.name}</TableCell>
+                        <TableCell style={{ textAlign: "left" }}>
+                          {post.author.name}
+                          {post.author.username && (
+                            <span
+                              style={{
+                                color: "#6b7280",
+                                fontSize: "0.85em",
+                                marginLeft: 4,
+                              }}
+                            >
+                              ({post.author.username})
+                            </span>
+                          )}
+                        </TableCell>
                         <TableCell $align="center">
                           <StatusBadge $status={getStatusText(post.status)}>
                             {getStatusText(post.status)}
@@ -771,7 +784,9 @@ export default function PostListPage() {
                                 </div>
                               </div>
                             </TableCell>
-                            <TableCell>{reply.author.name}</TableCell>
+                            <TableCell style={{ textAlign: "left" }}>
+                              {reply.author.name}
+                            </TableCell>
                             <TableCell $align="center">
                               <StatusBadge
                                 $status={getStatusText(reply.status)}
@@ -895,7 +910,9 @@ export default function PostListPage() {
                           </div>
                         </div>
                       </TableCell>
-                      <TableCell>{post.author.name}</TableCell>
+                      <TableCell style={{ textAlign: "left" }}>
+                        {post.author.name}
+                      </TableCell>
                       <TableCell $align="center">
                         <StatusBadge $status={getStatusText(post.status)}>
                           {getStatusText(post.status)}

--- a/src/features/board/components/Post/pages/PostListPage.tsx
+++ b/src/features/board/components/Post/pages/PostListPage.tsx
@@ -304,13 +304,6 @@ export default function PostListPage() {
 
   const handleSearch = () => {
     setCurrentPage(0);
-    setActiveSearchTerm(searchTerm);
-    setActiveSearchType(searchType);
-    setActiveStatusFilter(statusFilter);
-    setActiveTypeFilter(typeFilter);
-    setActivePriorityFilter(priorityFilter);
-    setActiveAssigneeFilter(assigneeFilter);
-    setActiveClientFilter(clientFilter);
   };
 
   const handleStatusFilterChange = (

--- a/src/features/board/components/Post/pages/PostListPage.tsx
+++ b/src/features/board/components/Post/pages/PostListPage.tsx
@@ -50,6 +50,7 @@ import PostDetailModal from "../components/DetailModal/ProjectPostDetailModal";
 import PostFormModal from "../components/FormModal/PostFormModal";
 import { useParams, useSearchParams } from "react-router-dom";
 import { showSuccessToast } from "@/utils/errorHandler";
+import { getProjectDetail } from "@/features/project/services/projectService";
 
 const formatDate = (dateString: string) => {
   let date;
@@ -155,23 +156,6 @@ export default function PostListPage() {
   const [clientFilter, setClientFilter] = useState("");
   const [isFilterExpanded, setIsFilterExpanded] = useState(true);
 
-  // 실제 검색에 사용될 상태 (검색 버튼 클릭 시 업데이트)
-  const [activeSearchTerm, setActiveSearchTerm] = useState("");
-  const [activeSearchType, setActiveSearchType] = useState<
-    "title" | "content" | "author"
-  >("title");
-  const [activeStatusFilter, setActiveStatusFilter] = useState<
-    PostStatus | "ALL"
-  >("ALL");
-  const [activeTypeFilter, setActiveTypeFilter] = useState<PostType | "ALL">(
-    "ALL"
-  );
-  const [activePriorityFilter, setActivePriorityFilter] = useState<
-    number | "ALL"
-  >("ALL");
-  const [activeAssigneeFilter, setActiveAssigneeFilter] = useState("");
-  const [activeClientFilter, setActiveClientFilter] = useState("");
-
   const [selectedPostId, setSelectedPostId] = useState<number | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isFormModalOpen, setIsFormModalOpen] = useState(false);
@@ -188,33 +172,70 @@ export default function PostListPage() {
     null
   );
 
+  const [projectSteps, setProjectSteps] = useState<any[]>([]);
+  const [stepFilter, setStepFilter] = useState<number | null>(null);
+
+  // 프로젝트 단계 정보 불러오기
+  useEffect(() => {
+    if (!projectId) return;
+    const fetchSteps = async () => {
+      try {
+        const res = await getProjectDetail(projectId);
+        if (res.data && res.data.steps) {
+          setProjectSteps(res.data.steps);
+          // 진행중 단계 중 id가 가장 작은 것 선택
+          const inProgressSteps = res.data.steps.filter(
+            (s: any) => s.projectStepStatus === "IN_PROGRESS"
+          );
+          if (inProgressSteps.length > 0) {
+            const minIdStep = inProgressSteps.reduce((prev, curr) =>
+              prev.id < curr.id ? prev : curr
+            );
+            setStepFilter(minIdStep.id);
+          } else if (res.data.steps.length > 0) {
+            setStepFilter(res.data.steps[0].id);
+          }
+        }
+      } catch (e) {
+        setProjectSteps([]);
+      }
+    };
+    fetchSteps();
+  }, [projectId]);
+
+  // stepFilter가 바뀌면 stepId도 변경
+  useEffect(() => {
+    if (stepFilter) {
+      window.history.replaceState(
+        null,
+        "",
+        `?stepName=${encodeURIComponent(
+          projectSteps.find((s) => s.id === stepFilter)?.name || ""
+        )}`
+      );
+    }
+  }, [stepFilter, projectSteps]);
+
   const fetchPosts = useCallback(async () => {
     setLoading(true);
     setError(null);
-
     let fetched: Post[] = [];
     let page = currentPage;
     let remain = itemsPerPage;
     let keepFetching = true;
     let totalCount = 0;
-
     try {
       while (remain > 0 && keepFetching) {
         const response = await getPostsWithComments(
-          Number(stepId),
+          Number(stepFilter),
           page,
           itemsPerPage
         );
         if (!response.data || response.data.content.length === 0) break;
-
-        // 소프트딜리트 제외
         const visible = response.data.content.filter(
           (post) => !post.isDeleted && !post.delete
         );
-
         fetched = [...fetched, ...visible];
-
-        // 실제 전체 개수는 백엔드에서 내려주는 totalElements에서 소프트딜리트 제외한 개수로 계산(임시)
         if (
           page === 0 &&
           response.data.page &&
@@ -222,19 +243,11 @@ export default function PostListPage() {
         ) {
           totalCount = response.data.page.totalElements;
         }
-
-        // 만약 10개가 모이면 break
         if (fetched.length >= itemsPerPage) break;
-
-        // 다음 페이지로
         page += 1;
         remain = itemsPerPage - fetched.length;
-
-        // 마지막 페이지라면 break
         if (response.data.content.length < itemsPerPage) keepFetching = false;
       }
-
-      // posts 가공 로직 추가
       const deletedWithReplies = fetched.filter(
         (post) =>
           (post.isDeleted || post.delete) &&
@@ -245,17 +258,13 @@ export default function PostListPage() {
         ...deletedWithReplies,
       ];
       setPosts(visiblePosts);
-
-      setTotalElements(totalCount); // 실제 전체 개수(소프트딜리트 제외 필요시 별도 계산)
+      setTotalElements(totalCount);
       setTotalPages(Math.ceil(totalCount / itemsPerPage));
-
-      // 첫 번째 게시글에서 projectId 가져오기
       if (visiblePosts.length > 0 && visiblePosts[0].project?.projectId) {
         setProjectId(visiblePosts[0].project.projectId);
       }
     } catch (err) {
       if (err instanceof Error && err.message.includes("완료")) {
-        // 완료 메시지는 무시
       } else {
         setError("게시글을 불러오는 중 오류가 발생했습니다.");
         console.error("게시글 목록 조회 중 오류:", err);
@@ -263,7 +272,7 @@ export default function PostListPage() {
     } finally {
       setLoading(false);
     }
-  }, [currentPage, itemsPerPage, stepId]);
+  }, [currentPage, itemsPerPage, stepFilter]);
 
   useEffect(() => {
     fetchPosts();
@@ -364,7 +373,10 @@ export default function PostListPage() {
     // 단계 변경으로 인해 게시글이 사라졌을 수 있음을 안내
     // (실제로는 백엔드에서 단계별로 게시글을 조회하므로,
     // 단계가 변경된 게시글은 현재 단계 목록에서 사라짐)
-    if (editingPostStepId !== null && editingPostStepId !== Number(stepId)) {
+    if (
+      editingPostStepId !== null &&
+      editingPostStepId !== Number(stepFilter)
+    ) {
       showSuccessToast(
         "게시글 수정 완료 - 단계가 변경되어 현재 목록에서 사라졌습니다."
       );
@@ -397,15 +409,6 @@ export default function PostListPage() {
     setAssigneeFilter("");
     setClientFilter("");
     setCurrentPage(0);
-
-    // 실제 검색 상태도 초기화
-    setActiveSearchTerm("");
-    setActiveSearchType("title");
-    setActiveStatusFilter("ALL");
-    setActiveTypeFilter("ALL");
-    setActivePriorityFilter("ALL");
-    setActiveAssigneeFilter("");
-    setActiveClientFilter("");
   };
 
   if (loading && posts.length === 0) {
@@ -537,6 +540,27 @@ export default function PostListPage() {
               <option value={1}>낮음 (1)</option>
               <option value={2}>보통 (2)</option>
               <option value={3}>높음 (3)</option>
+            </FilterSelect>
+          </FilterGroup>
+
+          {/* 단계 필터 */}
+          <FilterGroup>
+            <FilterLabel>단계</FilterLabel>
+            <FilterSelect
+              value={stepFilter ?? ""}
+              onChange={(e) => setStepFilter(Number(e.target.value))}
+              style={{ minWidth: 120 }}
+            >
+              {projectSteps.map((step) => (
+                <option key={step.id} value={step.id}>
+                  {step.name}{" "}
+                  {step.projectStepStatus === "IN_PROGRESS"
+                    ? "(진행중)"
+                    : step.projectStepStatus === "COMPLETED"
+                    ? "(완료)"
+                    : ""}
+                </option>
+              ))}
             </FilterSelect>
           </FilterGroup>
         </FilterGrid>
@@ -983,7 +1007,7 @@ export default function PostListPage() {
         mode={formModalMode}
         postId={formModalPostId || undefined}
         parentId={formModalParentId || undefined}
-        stepId={stepId ? Number(stepId) : undefined}
+        stepId={stepFilter ? Number(stepFilter) : undefined}
         projectId={projectId}
       />
     </PageContainer>

--- a/src/features/board/components/Question/components/QuestionAnswerModal/components/QuestionItem.tsx
+++ b/src/features/board/components/Question/components/QuestionAnswerModal/components/QuestionItem.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/features/project-d/services/questionService";
 import type { Question } from "@/features/project-d/types/question";
 import { useAuth } from "@/hooks/useAuth";
+import ClickableUsername from "@/components/ClickableUsername";
 
 interface QuestionItemProps {
   question: Question;
@@ -185,7 +186,26 @@ const QuestionItem: React.FC<QuestionItemProps> = ({
       <QuestionHeader>
         <div>
           <QuestionAuthor>
-            {question.author?.name}
+            <ClickableUsername
+              username={
+                question.authorName || question.author?.name || "undefined"
+              }
+              userId={question.author?.id || question.authorId}
+              onClick={() => {}} // 질문에서는 프로필 클릭 기능 없음
+              style={{ color: "#111827" }}
+            />
+            {question.authorUsername && (
+              <span
+                style={{
+                  fontSize: 11,
+                  color: "#6b7280",
+                  marginLeft: 1,
+                  fontWeight: 400,
+                }}
+              >
+                ({question.authorUsername})
+              </span>
+            )}
             <span
               style={{
                 fontSize: 11,

--- a/src/features/project-d/pages/ProjectDetailPage.tsx
+++ b/src/features/project-d/pages/ProjectDetailPage.tsx
@@ -335,22 +335,14 @@ export default function ProjectDetailPage() {
                 const isActive =
                   selectedStepId === step.id ||
                   step.projectStepStatus === "IN_PROGRESS";
-                const isWaiting = !isDone && !isActive;
+
                 return (
-                  <button
+                  <div
                     key={step.id}
-                    type="button"
                     aria-label={
                       step.name +
                       (isDone ? " 완료" : isActive ? " 진행중" : " 대기")
                     }
-                    onClick={() => {
-                      navigate(
-                        `/posts/${step.id}?stepName=${encodeURIComponent(
-                          step.name
-                        )}`
-                      );
-                    }}
                     style={{
                       display: "flex",
                       flexDirection: "column",
@@ -359,42 +351,10 @@ export default function ProjectDetailPage() {
                       minWidth: 70,
                       background: "none",
                       border: "none",
-                      cursor: "pointer",
+                      cursor: "not-allowed",
                       outline: "none",
                       padding: 0,
                       margin: 0,
-                    }}
-                    onMouseOver={(e) => {
-                      if (!isDone && !isActive) {
-                        (
-                          e.currentTarget.children[0] as HTMLElement
-                        ).style.background = "#f9fafb";
-                        (
-                          e.currentTarget.children[0] as HTMLElement
-                        ).style.border = "1.5px solid #fdb924";
-                        (
-                          e.currentTarget.children[1] as HTMLElement
-                        ).style.color = "#fdb924";
-                        (
-                          e.currentTarget.children[2] as HTMLElement
-                        ).style.color = "#fdb924";
-                      }
-                    }}
-                    onMouseOut={(e) => {
-                      if (!isDone && !isActive) {
-                        (
-                          e.currentTarget.children[0] as HTMLElement
-                        ).style.background = "#f5f5f5";
-                        (
-                          e.currentTarget.children[0] as HTMLElement
-                        ).style.border = "1.5px solid #e5e7eb";
-                        (
-                          e.currentTarget.children[1] as HTMLElement
-                        ).style.color = "#888";
-                        (
-                          e.currentTarget.children[2] as HTMLElement
-                        ).style.color = "#888";
-                      }
                     }}
                   >
                     <div
@@ -479,9 +439,9 @@ export default function ProjectDetailPage() {
                         transition: "color 0.2s",
                       }}
                     >
-                      {isDone ? "완료" : isActive ? "진행중" : "대기"}
+                      {isDone ? "완료" : isActive ? "진행중" : ""}
                     </div>
-                  </button>
+                  </div>
                 );
               })}
             </S.StepsList>

--- a/src/features/project-d/services/postService.ts
+++ b/src/features/project-d/services/postService.ts
@@ -321,6 +321,8 @@ export const updatePost = async (
     console.log("요청 데이터:", jsonData);
     console.log("새로 추가된 파일 개수:", files?.length || 0);
     console.log("삭제할 파일 ID:", postData.fileIdsToDelete);
+    console.log("삭제할 링크 ID:", postData.linkIdsToDelete);
+    console.log("새로 추가할 링크:", postData.newLinks);
 
     const response = await api.put<ApiResponse<Post>>(
       `/api/posts/${postId}`,

--- a/src/features/project-d/services/postService.ts
+++ b/src/features/project-d/services/postService.ts
@@ -86,6 +86,7 @@ export const createPost = async (
       status: postData.status,
       priority: postData.priority,
       ...(postData.parentId && { parentId: postData.parentId }),
+      ...(postData.newLinks && { newLinks: postData.newLinks }),
     };
 
     formData.append(
@@ -287,10 +288,18 @@ export const updatePost = async (
       type: postData.type,
       status: postData.status,
       priority: postData.priority,
-      stepId: postData.stepId || 1, // stepId가 필수 필드이므로 기본값 1 사용
+      stepId: postData.stepId || 1,
       ...(postData.fileIdsToDelete &&
         postData.fileIdsToDelete.length > 0 && {
           fileIdsToDelete: postData.fileIdsToDelete,
+        }),
+      ...(postData.linkIdsToDelete &&
+        postData.linkIdsToDelete.length > 0 && {
+          linkIdsToDelete: postData.linkIdsToDelete,
+        }),
+      ...(postData.newLinks &&
+        postData.newLinks.length > 0 && {
+          newLinks: postData.newLinks,
         }),
     };
 

--- a/src/features/project-d/services/postService.ts
+++ b/src/features/project-d/services/postService.ts
@@ -321,8 +321,6 @@ export const updatePost = async (
     console.log("요청 데이터:", jsonData);
     console.log("새로 추가된 파일 개수:", files?.length || 0);
     console.log("삭제할 파일 ID:", postData.fileIdsToDelete);
-    console.log("삭제할 링크 ID:", postData.linkIdsToDelete);
-    console.log("새로 추가할 링크:", postData.newLinks);
 
     const response = await api.put<ApiResponse<Post>>(
       `/api/posts/${postId}`,

--- a/src/features/project-d/types/post.ts
+++ b/src/features/project-d/types/post.ts
@@ -23,6 +23,7 @@ export enum PostPriority {
 export type Author = {
   id: number;
   name: string;
+  username?: string;
   email?: string;
   role?: string;
 };
@@ -77,6 +78,8 @@ export type Post = {
   projectStepId: number;
   authorIp: string;
   authorId: number;
+  authorName?: string;
+  authorUsername?: string;
   author: Author;
   approver?: Author;
   project?: Project;
@@ -190,6 +193,7 @@ export interface PostDetailReadResponse {
   authorIp: string | null;
   authorId: number | null;
   authorName: string;
+  authorUsername?: string;
   title: string;
   content: string | null;
   type: PostType;

--- a/src/features/project-d/types/post.ts
+++ b/src/features/project-d/types/post.ts
@@ -66,6 +66,7 @@ export type PostCreateData = {
   priority: PostPriority;
   stepId: number;
   parentId?: number | null;
+  newLinks?: string[];
 };
 
 // 게시글 타입 (기존 Post와 PostDetail 통합)
@@ -94,6 +95,7 @@ export type Post = {
   isDeleted?: boolean;
   delete?: boolean;
   files?: PostFile[];
+  links?: PostLink[];
 };
 
 // API 응답 타입
@@ -147,6 +149,8 @@ export type PostUpdateRequest = {
   priority?: PostPriority;
   stepId: number;
   fileIdsToDelete?: number[];
+  linkIdsToDelete?: number[];
+  newLinks?: string[];
 };
 
 // 게시글 검색 요청 데이터 타입
@@ -172,6 +176,12 @@ export interface PostFile {
   fileSize: string;
 }
 
+export interface PostLink {
+  id: number;
+  postId: number;
+  url: string;
+}
+
 export interface PostDetailReadResponse {
   postId: number | null;
   parentId: number | null;
@@ -188,6 +198,7 @@ export interface PostDetailReadResponse {
   updatedAt: string | null;
   files: PostFile[] | null;
   delete: boolean;
+  links?: PostLink[];
 }
 
 export interface PostSummaryReadResponse {

--- a/src/features/project-d/types/post.ts
+++ b/src/features/project-d/types/post.ts
@@ -50,6 +50,7 @@ export type Comment = {
   authorIp: string;
   authorId?: number;
   authorName?: string;
+  authorUsername?: string;
   author?: Author;
   content: string;
   createdAt: string;

--- a/src/features/project-d/types/question.ts
+++ b/src/features/project-d/types/question.ts
@@ -24,6 +24,9 @@ export type Question = {
   id: number;
   postId: number;
   authorIp: string;
+  authorId?: number;
+  authorName?: string;
+  authorUsername?: string;
   author: Author;
   content: string;
   status: QuestionStatus;
@@ -39,6 +42,9 @@ export type Answer = {
   questionId: number;
   parentId?: number | null; // 부모 답변 ID (댓글 기능을 위해 추가)
   authorIp: string;
+  authorId?: number;
+  authorName?: string;
+  authorUsername?: string;
   author: Author;
   content: string;
   status: AnswerStatus;

--- a/src/features/project/components/Board/ProjectBoard.styled.ts
+++ b/src/features/project/components/Board/ProjectBoard.styled.ts
@@ -228,25 +228,25 @@ export const Td = styled.td`
   }
 `;
 
-export const StatusBadge = styled.span<{ priority: PostPriority }>`
+export const StatusBadge = styled.span<{ $priority: PostPriority }>`
   padding: 4px 8px;
   border-radius: 999px;
   font-size: 12px;
   font-weight: 500;
-  color: ${({ priority }) =>
-    priority === "LOW"
+  color: ${({ $priority }) =>
+    $priority === "LOW"
       ? "#065f46"
-      : priority === "MEDIUM"
+      : $priority === "MEDIUM"
       ? "#92400e"
-      : priority === "HIGH"
+      : $priority === "HIGH"
       ? "#a21caf"
       : "#991b1b"};
-  background-color: ${({ priority }) =>
-    priority === "LOW"
+  background-color: ${({ $priority }) =>
+    $priority === "LOW"
       ? "#d1fae5"
-      : priority === "MEDIUM"
+      : $priority === "MEDIUM"
       ? "#fef3c7"
-      : priority === "HIGH"
+      : $priority === "HIGH"
       ? "#fce7f3"
       : "#fee2e2"};
 `;

--- a/src/features/project/components/Board/ProjectBoard.tsx
+++ b/src/features/project/components/Board/ProjectBoard.tsx
@@ -561,8 +561,15 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
               </span>
             )}
           </Td>
-          <Td>
-            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <Td style={{ textAlign: "left" }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+                marginLeft: "-13px",
+              }}
+            >
               <FiUser size={14} style={{ color: "#3b82f6" }} />
               <span>{post.authorName}</span>
             </div>
@@ -634,7 +641,7 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
                 </span>
               )}
             </Td>
-            <Td>
+            <Td style={{ textAlign: "left" }}>
               <div
                 style={{ display: "flex", alignItems: "center", gap: "8px" }}
               >
@@ -718,7 +725,7 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
                   </span>
                 )}
               </Td>
-              <Td>
+              <Td style={{ textAlign: "left" }}>
                 <div
                   style={{ display: "flex", alignItems: "center", gap: "8px" }}
                 >
@@ -798,7 +805,7 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
                 </span>
               )}
             </Td>
-            <Td>
+            <Td style={{ textAlign: "left" }}>
               <div
                 style={{ display: "flex", alignItems: "center", gap: "8px" }}
               >

--- a/src/features/project/components/Board/ProjectBoard.tsx
+++ b/src/features/project/components/Board/ProjectBoard.tsx
@@ -344,6 +344,18 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
       const response = await getProjectDetail(projectId);
       if (response.data) {
         setProjectSteps(response.data.steps);
+        // 진행중(IN_PROGRESS) 단계가 있으면 id가 가장 작은 단계로 stepFilter 설정
+        const inProgressSteps = response.data.steps.filter(
+          (s) => s.projectStepStatus === "IN_PROGRESS"
+        );
+        if (inProgressSteps.length > 0) {
+          const minIdStep = inProgressSteps.reduce((prev, curr) =>
+            prev.id < curr.id ? prev : curr
+          );
+          setStepFilter(minIdStep.id);
+        } else {
+          setStepFilter("ALL");
+        }
       }
     } catch (err) {
       console.error("프로젝트 단계 정보 불러오기 실패:", err);
@@ -1013,7 +1025,27 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
             >
               <DropdownButton
                 $active={stepFilter !== "ALL"}
-                $color={stepFilter === "ALL" ? "#6b7280" : "#10b981"}
+                $color={
+                  stepFilter === "ALL"
+                    ? "#6b7280"
+                    : (() => {
+                        const selectedStep = projectSteps.find(
+                          (step) => step.id === stepFilter
+                        );
+                        if (!selectedStep) return "#6b7280";
+
+                        switch (selectedStep.projectStepStatus) {
+                          case "IN_PROGRESS":
+                            return "#fdb924"; // 진행중 - 주황색
+                          case "COMPLETED":
+                            return "#10b981"; // 완료 - 초록색
+                          case "PENDING":
+                            return "#6b7280"; // 대기 - 회색
+                          default:
+                            return "#6b7280"; // 기본 - 회색
+                        }
+                      })()
+                }
                 $isOpen={isStepDropdownOpen}
                 onClick={handleStepDropdownToggle}
               >

--- a/src/features/project/components/Board/ProjectBoard.tsx
+++ b/src/features/project/components/Board/ProjectBoard.tsx
@@ -573,7 +573,7 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
             </TypeBadge>
           </Td>
           <Td>
-            <StatusBadge priority={post.priority as PostPriority}>
+            <StatusBadge $priority={post.priority as PostPriority}>
               {POST_PRIORITY_LABELS[post.priority as PostPriority] ??
                 post.priority}
             </StatusBadge>
@@ -648,7 +648,7 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
               </TypeBadge>
             </Td>
             <Td>
-              <StatusBadge priority={parentPost.priority as PostPriority}>
+              <StatusBadge $priority={parentPost.priority as PostPriority}>
                 {POST_PRIORITY_LABELS[parentPost.priority as PostPriority] ??
                   parentPost.priority}
               </StatusBadge>
@@ -732,7 +732,7 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
                 </TypeBadge>
               </Td>
               <Td>
-                <StatusBadge priority={child.priority as PostPriority}>
+                <StatusBadge $priority={child.priority as PostPriority}>
                   {POST_PRIORITY_LABELS[child.priority as PostPriority] ??
                     child.priority}
                 </StatusBadge>
@@ -812,7 +812,7 @@ const ProjectBoard: React.FC<ProjectBoardProps> = ({
               </TypeBadge>
             </Td>
             <Td>
-              <StatusBadge priority={orphan.priority as PostPriority}>
+              <StatusBadge $priority={orphan.priority as PostPriority}>
                 {POST_PRIORITY_LABELS[orphan.priority as PostPriority] ??
                   orphan.priority}
               </StatusBadge>

--- a/src/features/project/components/Progress/ProjectProgress.styled.ts
+++ b/src/features/project/components/Progress/ProjectProgress.styled.ts
@@ -38,34 +38,13 @@ export const StepItem = styled.div<{
   font-size: 15px;
   position: relative;
   min-width: 56px;
-  cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  cursor: default;
   gap: 2px;
   padding: 8px;
   border-radius: 8px;
   outline: none;
   border: 2px solid transparent;
   box-sizing: border-box;
-
-  ${({ selected }) =>
-    selected &&
-    `
-      transform: scale(1.08) translateY(-8px);
-      z-index: 10;
-    `}
-
-  &:hover {
-    transform: translateY(-2px);
-    color: #fdb924;
-  }
-
-  &:active {
-    transform: translateY(0);
-  }
-
-  &:focus {
-    outline: none;
-  }
 `;
 
 export const StepIcon = styled.div<{ active?: boolean; complete?: boolean }>`
@@ -89,15 +68,6 @@ export const StepIcon = styled.div<{ active?: boolean; complete?: boolean }>`
       complete || active ? "#ffffff" : "#9ca3af"};
     transition: color 0.2s ease;
   }
-
-  ${StepItem}:hover & {
-    background: #fdb924;
-    box-shadow: 0 0 0 3px rgba(253, 185, 36, 0.3);
-
-    svg {
-      color: white;
-    }
-  }
 `;
 
 export const StepLine = styled.div<{ active?: boolean; complete?: boolean }>`
@@ -108,8 +78,8 @@ export const StepLine = styled.div<{ active?: boolean; complete?: boolean }>`
   border-radius: 2px;
   position: relative;
   overflow: hidden;
-  align-self: flex-start;
-  margin-top: 19px;
+  align-self: center;
+  margin-bottom: 25px;
   transition: all 0.2s ease;
 `;
 
@@ -119,11 +89,6 @@ export const StepTitle = styled.div<{ active?: boolean; complete?: boolean }>`
   color: #6b7280;
   margin-bottom: 0;
   transition: all 0.2s ease;
-
-  ${StepItem}:hover & {
-    color: #fdb924;
-    font-weight: 600;
-  }
 `;
 
 export const StepStatus = styled.div<{ active?: boolean; complete?: boolean }>`
@@ -132,8 +97,4 @@ export const StepStatus = styled.div<{ active?: boolean; complete?: boolean }>`
     complete ? "#10b981" : active ? "#f59e0b" : "#9ca3af"};
   font-weight: 500;
   transition: all 0.2s ease;
-
-  ${StepItem}:hover & {
-    color: #fdb924;
-  }
 `;

--- a/src/features/project/components/Progress/ProjectProgress.tsx
+++ b/src/features/project/components/Progress/ProjectProgress.tsx
@@ -90,12 +90,6 @@ const ProjectProgress: React.FC<ProjectProgressProps> = ({
                 active={isActive || isSelected}
                 complete={isComplete}
                 selected={isSelected}
-                style={{
-                  cursor: "not-allowed",
-                  border: "none",
-                  background: "transparent",
-                  boxShadow: "none",
-                }}
               >
                 <StepIcon active={isActive || isSelected} complete={isComplete}>
                   <Icon size={18} />

--- a/src/features/project/components/Progress/ProjectProgress.tsx
+++ b/src/features/project/components/Progress/ProjectProgress.tsx
@@ -51,7 +51,7 @@ const ProjectProgress: React.FC<ProjectProgressProps> = ({
       case "IN_PROGRESS":
         return "진행중";
       case "PENDING":
-        return "대기";
+        return "";
       default:
         return status;
     }
@@ -90,9 +90,8 @@ const ProjectProgress: React.FC<ProjectProgressProps> = ({
                 active={isActive || isSelected}
                 complete={isComplete}
                 selected={isSelected}
-                onClick={() => handleStepClick(step.id)}
                 style={{
-                  cursor: onStepSelect ? "pointer" : "default",
+                  cursor: "not-allowed",
                   border: "none",
                   background: "transparent",
                   boxShadow: "none",

--- a/src/features/user/services/userService.ts
+++ b/src/features/user/services/userService.ts
@@ -52,22 +52,30 @@ export interface UserInfo {
   role: string;
 }
 
+// UserSummaryResponse 타입 (새로운 API 응답에 맞춤)
+export interface UserSummaryResponse {
+  id: number;
+  username: string;
+  name: string;
+  role: string;
+}
+
 // 사용자명 검색
 export const searchUsernames = async (
   username: string,
   projectId: number
-): Promise<ApiResponse<UserInfo[]>> => {
+): Promise<ApiResponse<UserSummaryResponse[]>> => {
   try {
-    const response = await api.get<ApiResponse<UserInfo[]>>(
+    const response = await api.get<ApiResponse<UserSummaryResponse[]>>(
       "/api/users/search",
       {
         params: {
-          username,
           projectId,
+          username,
         },
       }
     );
-    return handleApiResponse<UserInfo[]>(response);
+    return handleApiResponse<UserSummaryResponse[]>(response);
   } catch (error) {
     if (error instanceof ApiError) throw error;
     if (error instanceof AxiosError) {

--- a/src/features/user/services/userService.ts
+++ b/src/features/user/services/userService.ts
@@ -54,7 +54,8 @@ export interface UserInfo {
 
 // 사용자명 검색
 export const searchUsernames = async (
-  username: string
+  username: string,
+  projectId: number
 ): Promise<ApiResponse<UserInfo[]>> => {
   try {
     const response = await api.get<ApiResponse<UserInfo[]>>(
@@ -62,6 +63,7 @@ export const searchUsernames = async (
       {
         params: {
           username,
+          projectId,
         },
       }
     );

--- a/src/hooks/useMention.ts
+++ b/src/hooks/useMention.ts
@@ -2,6 +2,14 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { searchUsernames } from "@/features/user/services/userService";
 
+// UserSummaryResponse 타입을 직접 정의
+interface UserSummaryResponse {
+  id: number;
+  username: string;
+  name: string;
+  role: string;
+}
+
 interface MentionState {
   isActive: boolean;
   query: string;
@@ -41,8 +49,10 @@ export const useMention = () => {
         // API 응답이 유효한지 확인하고 안전하게 처리
         const userData = response?.data;
         if (userData && Array.isArray(userData)) {
-          // UserInfo 객체 배열에서 username만 추출하여 문자열 배열로 변환
-          const usernames = userData.map((user) => user.username);
+          // UserSummaryResponse 객체 배열에서 username만 추출하여 문자열 배열로 변환
+          const usernames = userData.map(
+            (user: UserSummaryResponse) => user.username
+          );
 
           setMentionState((prev) => ({
             ...prev,

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import { searchUsernames } from "@/features/user/services/userService";
 
 // UserSummaryResponse 타입을 직접 정의
@@ -19,6 +20,7 @@ interface UserProfileState {
 }
 
 export const useUserProfile = () => {
+  const navigate = useNavigate();
   const [profileState, setProfileState] = useState<UserProfileState>({
     isOpen: false,
     username: "",
@@ -95,11 +97,13 @@ export const useUserProfile = () => {
     }));
   }, []);
 
-  const handleViewProfile = useCallback((userId: number) => {
-    // 프로필 보기 로직 구현
-    console.log("프로필 보기:", userId);
-    // 예: navigate(`/user/${userId}`);
-  }, []);
+  const handleViewProfile = useCallback(
+    (userId: number) => {
+      // 프로필 보기 페이지로 이동
+      navigate("/my");
+    },
+    [navigate]
+  );
 
   const handleSendMessage = useCallback((userId: number) => {
     // 쪽지 보내기 로직 구현

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,6 +1,14 @@
 import { useState, useCallback } from "react";
 import { searchUsernames } from "@/features/user/services/userService";
 
+// UserSummaryResponse 타입을 직접 정의
+interface UserSummaryResponse {
+  id: number;
+  username: string;
+  name: string;
+  role: string;
+}
+
 interface UserProfileState {
   isOpen: boolean;
   username: string;
@@ -36,11 +44,13 @@ export const useUserProfile = () => {
       let isAdmin = false;
 
       try {
-        const response = await searchUsernames(username);
+        // projectId가 필요하므로 현재 URL에서 가져오거나 기본값 사용
+        const currentProjectId = 1; // 기본값 또는 URL에서 추출
+        const response = await searchUsernames(username, currentProjectId);
         if (response.data && response.data.length > 0) {
           // 정확한 사용자명 매칭을 위해 필터링
           const exactMatch = response.data.find(
-            (user) => user.username === username
+            (user: UserSummaryResponse) => user.username === username
           );
           const userInfo = exactMatch || response.data[0]; // 정확한 매칭이 없으면 첫 번째 결과 사용
 


### PR DESCRIPTION
## 📌 개요
게시글 링크 첨부 기능 전체 연동 및 멘션 UI 개선, 게시글/댓글 username 출력 적용

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [x] 스타일 수정 (Style)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- 게시글 생성, 수정 시 링크 첨부 기능 API 연동
- 이력 상세 정보에 링크 필드 포함되도록 수정
- 게시글 상세 모달 및 복수 URL 표시 스타일 개선
- 멘션 기능 API 연동 및 선택/표시 UI 개선
- 멘션 선택 시 공백 자동 추가 및 클릭 시 API 동작 수정
- 게시글/댓글 username 출력 적용
- 진행 중인 단계 중 가장 빠른 id의 단계 선택되도록 수정
- 드롭다운 색상 및 단계 텍스트 스타일 조정
- 불필요한 로그 및 클릭 이벤트 제거
- prop 전달 오류 수정

## 🔍 관련 이슈
- Close #144

## 🧪 테스트 결과
- 게시글 생성/수정 시 링크 정상 작동 확인
- 멘션 기능 입력/선택/클릭 UI 정상 동작 확인
- 게시글, 댓글에 username 정상 출력 확인

## 👀 리뷰어에게 요청사항
- 멘션 UI 흐름 및 링크 이력 반영 확인 부탁드립니다

## 📎 기타 참고 사항
- 없음