### PR TITLE
[Style] 이력 상세 보기 UI 개선 및 복구 기능 추가, 이력 정보 가시성 및 표현 방식 개선

### DIFF
--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -921,7 +921,7 @@ export default function ActivityLogDetailModal({
       case "USER":
         return <FiUser size={14} style={{ color: "#8b5cf6" }} />;
       case "COMPANY":
-        return <FiHome size={14} style={{ color: "#f59e0b" }} />;
+        return <FiHome size={14} style={{ color: "#8b5cf6" }} />;
       case "PROJECT":
         return <FaProjectDiagram size={14} style={{ color: "#3b82f6" }} />;
       case "STEP":
@@ -929,7 +929,7 @@ export default function ActivityLogDetailModal({
       case "POST":
         return <FiFileText size={14} style={{ color: "#10b981" }} />;
       case "INQUIRY":
-        return <FiMessageSquare size={14} style={{ color: "#06b6d4" }} />;
+        return <FiMessageSquare size={14} style={{ color: "#f59e0b" }} />;
       case "CHECK_LIST":
         return <FiCheckSquare size={14} style={{ color: "#ec4899" }} />;
       default:

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -1015,7 +1015,7 @@ export default function ActivityLogDetailModal({
                   </InfoValue>
                 </InfoItem>
                 <InfoItem>
-                  <InfoLabel>변경자 역할</InfoLabel>
+                  <InfoLabel>변경자 권한</InfoLabel>
                   <InfoValue>
                     {getRoleIcon(detail.changerRole)}
                     {getRoleDisplayName(detail.changerRole)}

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -15,6 +15,8 @@ import {
   FiLayers,
   FiCheckSquare,
   FiRotateCcw,
+  FiCopy,
+  FiCheck,
 } from "react-icons/fi";
 import { RiUserSettingsLine } from "react-icons/ri";
 import { FaProjectDiagram } from "react-icons/fa";
@@ -302,6 +304,26 @@ const ChangeColumnBox = styled.div`
   gap: 6px;
 `;
 
+const CopyButton = styled.button<{ copied: boolean }>`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  color: ${({ copied }) => (copied ? "#10b981" : "#6b7280")};
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+
+  &:hover {
+    background-color: #f3f4f6;
+    color: ${({ copied }) => (copied ? "#10b981" : "#374151")};
+  }
+`;
+
 export default function ActivityLogDetailModal({
   isOpen,
   onClose,
@@ -312,6 +334,7 @@ export default function ActivityLogDetailModal({
   const [error, setError] = useState<string | null>(null);
   const [restoring, setRestoring] = useState(false);
   const [restoreError, setRestoreError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (isOpen && historyId) {
@@ -370,6 +393,18 @@ export default function ActivityLogDetailModal({
       setRestoreError("데이터 복구에 실패했습니다. 다시 시도해주세요.");
     } finally {
       setRestoring(false);
+    }
+  };
+
+  const handleCopyId = async () => {
+    if (!detail) return;
+
+    try {
+      await navigator.clipboard.writeText(detail.id);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("클립보드 복사 실패:", err);
     }
   };
 
@@ -1056,7 +1091,12 @@ export default function ActivityLogDetailModal({
         <ModalHeader>
           <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
             <ModalTitle>이력 상세 정보</ModalTitle>
-            {detail && <ModalSubtitle>ID: {detail.id}</ModalSubtitle>}
+            {detail && (
+              <CopyButton copied={copied} onClick={handleCopyId}>
+                ID: {detail.id}
+                {copied ? <FiCheck size={14} /> : <FiCopy size={14} />}
+              </CopyButton>
+            )}
           </div>
           <CloseButton onClick={onClose}>
             <FiX />

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -1047,8 +1047,10 @@ export default function ActivityLogDetailModal({
           <>
             <ContentSection>
               <SectionTitle>
-                <FiInfo style={{ color: "#fdb924" }} />
-                기본 정보
+                <SectionTitleContent>
+                  <FiInfo style={{ color: "#fdb924" }} />
+                  기본 정보
+                </SectionTitleContent>
               </SectionTitle>
               <InfoGrid>
                 <InfoItem>
@@ -1078,8 +1080,10 @@ export default function ActivityLogDetailModal({
 
             <ContentSection>
               <SectionTitle>
-                <FiUser style={{ color: "#fdb924" }} />
-                변경자 정보
+                <SectionTitleContent>
+                  <FiUser style={{ color: "#fdb924" }} />
+                  변경자 정보
+                </SectionTitleContent>
               </SectionTitle>
               <InfoGrid>
                 <InfoItem>
@@ -1106,8 +1110,10 @@ export default function ActivityLogDetailModal({
               <div style={{ display: "flex", gap: "20px" }}>
                 <div style={{ flex: "1" }}>
                   <SectionTitle>
-                    <FiCalendar style={{ color: "#fdb924" }} />
-                    시간 정보
+                    <SectionTitleContent>
+                      <FiCalendar style={{ color: "#fdb924" }} />
+                      시간 정보
+                    </SectionTitleContent>
                   </SectionTitle>
                   <InfoGrid>
                     <InfoItem>
@@ -1120,8 +1126,10 @@ export default function ActivityLogDetailModal({
                 {detail.message && (
                   <div style={{ flex: "1" }}>
                     <SectionTitle>
-                      <FiMessageSquare style={{ color: "#fdb924" }} />
-                      작업상세
+                      <SectionTitleContent>
+                        <FiMessageSquare style={{ color: "#fdb924" }} />
+                        작업상세
+                      </SectionTitleContent>
                     </SectionTitle>
                     <div style={{ padding: "8px 0" }}>
                       <span

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -13,6 +13,7 @@ import {
   FiHome,
   FiFileText,
   FiLayers,
+  FiCheckSquare,
 } from "react-icons/fi";
 import { RiUserSettingsLine } from "react-icons/ri";
 import { FaProjectDiagram } from "react-icons/fa";
@@ -345,6 +346,8 @@ export default function ActivityLogDetailModal({
         return "문의";
       case "CHAT":
         return "채팅";
+      case "CHECK_LIST":
+        return "체크리스트";
       default:
         return domainType;
     }
@@ -925,6 +928,10 @@ export default function ActivityLogDetailModal({
         return <FiLayers size={14} style={{ color: "#6366f1" }} />;
       case "POST":
         return <FiFileText size={14} style={{ color: "#10b981" }} />;
+      case "INQUIRY":
+        return <FiMessageSquare size={14} style={{ color: "#06b6d4" }} />;
+      case "CHECK_LIST":
+        return <FiCheckSquare size={14} style={{ color: "#ec4899" }} />;
       default:
         return <FiUser size={14} style={{ color: "#6b7280" }} />;
     }

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -83,6 +83,14 @@ const ModalTitle = styled.h2`
   }
 `;
 
+const ModalSubtitle = styled.div`
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin-top: 4px;
+  padding-left: 16px;
+  font-weight: 500;
+`;
+
 const CloseButton = styled.button`
   background: none;
   border: none;
@@ -1046,7 +1054,10 @@ export default function ActivityLogDetailModal({
     <ModalOverlay isOpen={isOpen} onClick={onClose}>
       <ModalContent onClick={(e) => e.stopPropagation()}>
         <ModalHeader>
-          <ModalTitle>이력 상세 정보</ModalTitle>
+          <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+            <ModalTitle>이력 상세 정보</ModalTitle>
+            {detail && <ModalSubtitle>ID: {detail.id}</ModalSubtitle>}
+          </div>
           <CloseButton onClick={onClose}>
             <FiX />
           </CloseButton>
@@ -1082,10 +1093,6 @@ export default function ActivityLogDetailModal({
                 <InfoItem>
                   <InfoLabel>대상 ID</InfoLabel>
                   <InfoValue>{detail.domainId}</InfoValue>
-                </InfoItem>
-                <InfoItem>
-                  <InfoLabel>이력 ID</InfoLabel>
-                  <InfoValue>{detail.id}</InfoValue>
                 </InfoItem>
               </InfoGrid>
             </ContentSection>

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -149,11 +149,12 @@ const InfoValue = styled.span`
 const StatusBadge = styled.span<{ type: string }>`
   display: inline-flex;
   align-items: center;
-  gap: 3px;
+  justify-content: center;
   padding: 3px 10px;
   border-radius: 16px;
   font-size: 0.75rem;
   font-weight: 500;
+  width: 50px;
   background-color: ${({ type }) => {
     switch (type) {
       case "CREATED":
@@ -1049,18 +1050,13 @@ export default function ActivityLogDetailModal({
               <SectionTitle>
                 <SectionTitleContent>
                   <FiInfo style={{ color: "#fdb924" }} />
-                  기본 정보
+                  작업 정보
                 </SectionTitleContent>
               </SectionTitle>
               <InfoGrid>
                 <InfoItem>
-                  <InfoLabel>이력 ID</InfoLabel>
-                  <InfoValue>{detail.id}</InfoValue>
-                </InfoItem>
-                <InfoItem>
                   <InfoLabel>작업 유형</InfoLabel>
                   <StatusBadge type={detail.historyType}>
-                    {getActionIcon(detail.historyType)}
                     {getActionDisplayName(detail.historyType)}
                   </StatusBadge>
                 </InfoItem>
@@ -1075,6 +1071,10 @@ export default function ActivityLogDetailModal({
                   <InfoLabel>대상 ID</InfoLabel>
                   <InfoValue>{detail.domainId}</InfoValue>
                 </InfoItem>
+                <InfoItem>
+                  <InfoLabel>이력 ID</InfoLabel>
+                  <InfoValue>{detail.id}</InfoValue>
+                </InfoItem>
               </InfoGrid>
             </ContentSection>
 
@@ -1086,10 +1086,6 @@ export default function ActivityLogDetailModal({
                 </SectionTitleContent>
               </SectionTitle>
               <InfoGrid>
-                <InfoItem>
-                  <InfoLabel>변경자 ID</InfoLabel>
-                  <InfoValue>{detail.changerId}</InfoValue>
-                </InfoItem>
                 <InfoItem>
                   <InfoLabel>변경자 이름</InfoLabel>
                   <InfoValue>
@@ -1103,48 +1099,36 @@ export default function ActivityLogDetailModal({
                     {getRoleDisplayName(detail.changerRole)}
                   </InfoValue>
                 </InfoItem>
+                <InfoItem>
+                  <InfoLabel>변경자 ID</InfoLabel>
+                  <InfoValue>{detail.changerId}</InfoValue>
+                </InfoItem>
               </InfoGrid>
             </ContentSection>
 
             <ContentSection>
-              <div style={{ display: "flex", gap: "20px" }}>
-                <div style={{ flex: "1" }}>
-                  <SectionTitle>
-                    <SectionTitleContent>
-                      <FiCalendar style={{ color: "#fdb924" }} />
-                      시간 정보
-                    </SectionTitleContent>
-                  </SectionTitle>
-                  <InfoGrid>
-                    <InfoItem>
-                      <InfoLabel>변경 발생 시간</InfoLabel>
-                      <InfoValue>{formatDate(detail.changedAt)}</InfoValue>
-                    </InfoItem>
-                  </InfoGrid>
-                </div>
-
+              <SectionTitle>
+                <SectionTitleContent>
+                  <FiCalendar style={{ color: "#fdb924" }} />
+                  시간 정보
+                </SectionTitleContent>
+              </SectionTitle>
+              <InfoGrid>
+                <InfoItem>
+                  <InfoLabel>변경 발생 시간</InfoLabel>
+                  <InfoValue>{formatDate(detail.changedAt)}</InfoValue>
+                </InfoItem>
                 {detail.message && (
-                  <div style={{ flex: "1" }}>
-                    <SectionTitle>
-                      <SectionTitleContent>
-                        <FiMessageSquare style={{ color: "#fdb924" }} />
-                        작업상세
-                      </SectionTitleContent>
-                    </SectionTitle>
-                    <div style={{ padding: "8px 0" }}>
-                      <span
-                        style={{
-                          fontSize: "0.875rem",
-                          color: "#111827",
-                          lineHeight: "1.5",
-                        }}
-                      >
-                        {detail.message}
-                      </span>
-                    </div>
-                  </div>
+                  <InfoItem>
+                    <InfoLabel>작업상세</InfoLabel>
+                    <InfoValue
+                      style={{ fontSize: "0.8rem", lineHeight: "1.4" }}
+                    >
+                      {detail.message}
+                    </InfoValue>
+                  </InfoItem>
                 )}
-              </div>
+              </InfoGrid>
             </ContentSection>
 
             {renderChanges()}

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -989,20 +989,32 @@ export default function ActivityLogDetailModal({
   const getRoleDisplayName = (role: string) => {
     const roleMap: Record<string, string> = {
       ROLE_ADMIN: "관리자",
+      ROLE_USER: "사용자",
       ROLE_DEV_EMPLOYEE: "개발사 직원",
       ROLE_CLIENT_EMPLOYEE: "고객사 직원",
       ROLE_CLIENT_MANAGER: "고객사 담당자",
       ROLE_DEV_MANAGER: "개발사 담당자",
+      ROLE_SYSTEM_ADMIN: "시스템 관리자",
+      ROLE_TEAM_LEADER: "팀장",
     };
     return roleMap[role] || role;
   };
 
   // 역할에 따른 아이콘 반환
   const getRoleIcon = (role: string) => {
-    if (role === "ROLE_ADMIN") {
-      return <RiUserSettingsLine size={14} style={{ color: "#8b5cf6" }} />;
-    } else {
-      return <FiUser size={14} style={{ color: "#6b7280" }} />;
+    switch (role) {
+      case "ROLE_ADMIN":
+      case "ROLE_SYSTEM_ADMIN":
+        return <RiUserSettingsLine size={14} style={{ color: "#8b5cf6" }} />;
+      case "ROLE_TEAM_LEADER":
+        return <FiUser size={14} style={{ color: "#3b82f6" }} />;
+      case "ROLE_USER":
+      case "ROLE_DEV_EMPLOYEE":
+      case "ROLE_CLIENT_EMPLOYEE":
+      case "ROLE_CLIENT_MANAGER":
+      case "ROLE_DEV_MANAGER":
+      default:
+        return <FiUser size={14} style={{ color: "#6b7280" }} />;
     }
   };
 

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -414,7 +414,11 @@ export default function ActivityLogDetailModal({
                     !key.startsWith("_") &&
                     key !== "delete" &&
                     key !== "deletedAt" &&
-                    key !== "updatedAt"
+                    key !== "updatedAt" &&
+                    key !== "password" &&
+                    key !== "confirmPassword" &&
+                    key !== "oldPassword" &&
+                    key !== "newPassword"
                 )
                 .map(([key, value]) => (
                   <DataRow key={key}>
@@ -448,7 +452,11 @@ export default function ActivityLogDetailModal({
                     !key.startsWith("_") &&
                     key !== "delete" &&
                     key !== "deletedAt" &&
-                    key !== "updatedAt"
+                    key !== "updatedAt" &&
+                    key !== "password" &&
+                    key !== "confirmPassword" &&
+                    key !== "oldPassword" &&
+                    key !== "newPassword"
                 )
                 .map(([key, value]) => (
                   <DataRow key={key}>
@@ -479,7 +487,11 @@ export default function ActivityLogDetailModal({
           key.startsWith("_") ||
           key === "delete" ||
           key === "deletedAt" ||
-          key === "updatedAt"
+          key === "updatedAt" ||
+          key === "password" ||
+          key === "confirmPassword" ||
+          key === "oldPassword" ||
+          key === "newPassword"
         );
       });
 

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -14,6 +14,7 @@ import {
   FiFileText,
   FiLayers,
   FiCheckSquare,
+  FiRotateCcw,
 } from "react-icons/fi";
 import { RiUserSettingsLine } from "react-icons/ri";
 import { FaProjectDiagram } from "react-icons/fa";
@@ -106,6 +107,12 @@ const SectionTitle = styled.h3`
   font-weight: 600;
   color: #374151;
   margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const SectionTitleContent = styled.div`
   display: flex;
   align-items: center;
   gap: 6px;
@@ -222,11 +229,43 @@ const HighlightedValue = styled.span`
   border-radius: 3px;
 `;
 
+const RestoreButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background-color: #6b7280;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background-color: #4b5563;
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  &:disabled {
+    background-color: #d1d5db;
+    cursor: not-allowed;
+    transform: none;
+  }
+`;
+
 const ErrorMessage = styled.div`
   color: #ef4444;
-  text-align: center;
-  padding: 16px;
   font-size: 0.875rem;
+  margin-top: 8px;
+  padding: 8px 12px;
+  background-color: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
 `;
 
 const ChangesGrid = styled.div`
@@ -262,6 +301,8 @@ export default function ActivityLogDetailModal({
   const [detail, setDetail] = useState<ActivityLogDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [restoring, setRestoring] = useState(false);
+  const [restoreError, setRestoreError] = useState<string | null>(null);
 
   useEffect(() => {
     if (isOpen && historyId) {
@@ -297,6 +338,29 @@ export default function ActivityLogDetailModal({
       setError("이력 상세 정보를 불러오는데 실패했습니다.");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleRestore = async () => {
+    if (!detail) return;
+
+    setRestoring(true);
+    setRestoreError(null);
+
+    try {
+      // TODO: 실제 복구 API 호출
+      // const response = await restoreData(detail.id);
+
+      // 임시로 성공 메시지 표시
+      console.log("데이터 복구 요청:", detail.id);
+
+      // 성공 시 모달 닫기
+      onClose();
+    } catch (err) {
+      console.error("데이터 복구 실패:", err);
+      setRestoreError("데이터 복구에 실패했습니다. 다시 시도해주세요.");
+    } finally {
+      setRestoring(false);
     }
   };
 
@@ -403,8 +467,10 @@ export default function ActivityLogDetailModal({
       return (
         <ChangesSection>
           <SectionTitle>
-            <FiPlus style={{ color: "#fdb924" }} />
-            생성된 데이터
+            <SectionTitleContent>
+              <FiPlus style={{ color: "#fdb924" }} />
+              생성된 데이터
+            </SectionTitleContent>
           </SectionTitle>
           <DataContainer>
             <DataDisplay>
@@ -441,8 +507,14 @@ export default function ActivityLogDetailModal({
       return (
         <ChangesSection>
           <SectionTitle>
-            <FiTrash2 style={{ color: "#fdb924" }} />
-            삭제된 데이터
+            <SectionTitleContent>
+              <FiTrash2 style={{ color: "#fdb924" }} />
+              삭제된 데이터
+            </SectionTitleContent>
+            <RestoreButton onClick={handleRestore} disabled={restoring}>
+              <FiRotateCcw />
+              {restoring ? "복구 중..." : "복구"}
+            </RestoreButton>
           </SectionTitle>
           <DataContainer>
             <DataDisplay>
@@ -502,8 +574,14 @@ export default function ActivityLogDetailModal({
       return (
         <ChangesSection>
           <SectionTitle>
-            <FiEdit style={{ color: "#fdb924" }} />
-            변경된 내용
+            <SectionTitleContent>
+              <FiEdit style={{ color: "#fdb924" }} />
+              변경된 내용
+            </SectionTitleContent>
+            <RestoreButton onClick={handleRestore} disabled={restoring}>
+              <FiRotateCcw />
+              {restoring ? "복구 중..." : "복구"}
+            </RestoreButton>
           </SectionTitle>
           <ChangesGrid>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
@@ -1062,6 +1140,12 @@ export default function ActivityLogDetailModal({
             </ContentSection>
 
             {renderChanges()}
+
+            {/* 수정/삭제 작업에만 복구 버튼 표시 */}
+            {(detail.historyType === "UPDATED" ||
+              detail.historyType === "DELETED") && (
+              <>{restoreError && <ErrorMessage>{restoreError}</ErrorMessage>}</>
+            )}
           </>
         )}
       </ModalContent>

--- a/src/features/admin/components/ActivityLogDetailModal.tsx
+++ b/src/features/admin/components/ActivityLogDetailModal.tsx
@@ -1178,7 +1178,7 @@ export default function ActivityLogDetailModal({
                   <InfoValue>{formatDate(detail.changedAt)}</InfoValue>
                 </InfoItem>
                 {detail.message && (
-                  <InfoItem>
+                  <InfoItem style={{ marginLeft: "115px" }}>
                     <InfoLabel>작업상세</InfoLabel>
                     <InfoValue
                       style={{ fontSize: "0.8rem", lineHeight: "1.4" }}

--- a/src/features/admin/pages/ActivityLogPage.tsx
+++ b/src/features/admin/pages/ActivityLogPage.tsx
@@ -141,7 +141,7 @@ export default function ActivityLogPage() {
   const LOG_TYPE_OPTIONS = [
     { value: "ALL", label: "전체", icon: FiGrid, color: "#6b7280" },
     { value: "USER", label: "회원", icon: FiUser, color: "#6366f1" },
-    { value: "COMPANY", label: "업체", icon: FiHome, color: "#f59e0b" },
+    { value: "COMPANY", label: "업체", icon: FiHome, color: "#8b5cf6" },
     {
       value: "PROJECT",
       label: "프로젝트",
@@ -159,7 +159,7 @@ export default function ActivityLogPage() {
       value: "INQUIRY",
       label: "문의",
       icon: FiMessageSquare,
-      color: "#06b6d4",
+      color: "#f59e0b",
     },
     {
       value: "CHECK_LIST",
@@ -272,7 +272,7 @@ export default function ActivityLogPage() {
       case "USER":
         return <FiUser style={{ color: "#6366f1" }} />;
       case "COMPANY":
-        return <FiHome style={{ color: "#f59e0b" }} />;
+        return <FiHome style={{ color: "#8b5cf6" }} />;
       case "PROJECT":
         return <FaProjectDiagram style={{ color: "#3b82f6" }} />;
       case "STEP":
@@ -280,7 +280,7 @@ export default function ActivityLogPage() {
       case "POST":
         return <FiFileText style={{ color: "#10b981" }} />;
       case "INQUIRY":
-        return <FiMessageSquare style={{ color: "#06b6d4" }} />;
+        return <FiMessageSquare style={{ color: "#f59e0b" }} />;
       case "CHECK_LIST":
         return <FiCheckSquare style={{ color: "#ec4899" }} />;
       default:

--- a/src/features/admin/pages/ActivityLogPage.tsx
+++ b/src/features/admin/pages/ActivityLogPage.tsx
@@ -49,6 +49,8 @@ import {
   FiChevronDown,
   FiLayers,
   FiGrid,
+  FiMessageSquare,
+  FiCheckSquare,
 } from "react-icons/fi";
 import { FaProjectDiagram } from "react-icons/fa";
 import { LuUserRoundCog } from "react-icons/lu";
@@ -67,7 +69,14 @@ interface ActivityLog {
   userName: string;
   userRole: string;
   action: string;
-  targetType: "POST" | "USER" | "PROJECT" | "COMPANY" | "STEP";
+  targetType:
+    | "POST"
+    | "USER"
+    | "PROJECT"
+    | "COMPANY"
+    | "STEP"
+    | "INQUIRY"
+    | "CHECK_LIST";
   targetName: string;
   details: string;
   ipAddress: string;
@@ -146,6 +155,18 @@ export default function ActivityLogPage() {
       color: "#6366f1",
     },
     { value: "POST", label: "게시글", icon: FiFileText, color: "#10b981" },
+    {
+      value: "INQUIRY",
+      label: "문의",
+      icon: FiMessageSquare,
+      color: "#06b6d4",
+    },
+    {
+      value: "CHECK_LIST",
+      label: "체크리스트",
+      icon: FiCheckSquare,
+      color: "#ec4899",
+    },
   ];
 
   // 드롭다운 외부 클릭 감지
@@ -258,6 +279,10 @@ export default function ActivityLogPage() {
         return <FiLayers style={{ color: "#6366f1" }} />;
       case "POST":
         return <FiFileText style={{ color: "#10b981" }} />;
+      case "INQUIRY":
+        return <FiMessageSquare style={{ color: "#06b6d4" }} />;
+      case "CHECK_LIST":
+        return <FiCheckSquare style={{ color: "#ec4899" }} />;
       default:
         return <FiGrid style={{ color: "#6b7280" }} />;
     }
@@ -515,7 +540,7 @@ export default function ActivityLogPage() {
   return (
     <PageContainer>
       <Header>
-        <Title>변경 이력</Title>
+        <Title>이력 관리</Title>
         <Description>
           사용자들의 사이트 활동 내역을 확인할 수 있습니다
         </Description>

--- a/src/features/admin/services/activityLogService.ts
+++ b/src/features/admin/services/activityLogService.ts
@@ -27,7 +27,14 @@ interface PageResponse<T> {
 interface HistorySimpleResponse {
   id: string;
   historyType: "CREATED" | "UPDATED" | "DELETED";
-  domainType: "POST" | "USER" | "PROJECT" | "COMPANY" | "STEP";
+  domainType:
+    | "POST"
+    | "USER"
+    | "PROJECT"
+    | "COMPANY"
+    | "STEP"
+    | "INQUIRY"
+    | "CHECK_LIST";
   domainId: number;
   changedAt: string;
   changerId: string;
@@ -135,6 +142,10 @@ export const transformHistoryToActivityLog = (
         return "프로젝트 단계";
       case "POST":
         return "게시글";
+      case "INQUIRY":
+        return "문의";
+      case "CHECK_LIST":
+        return "체크리스트";
       default:
         return domainType;
     }

--- a/src/features/admin/types/activityLog.ts
+++ b/src/features/admin/types/activityLog.ts
@@ -29,7 +29,9 @@ export interface HistorySimpleResponse {
     | "PROJECT_STEP"
     | "POST"
     | "QUESTION"
-    | "CHAT";
+    | "CHAT"
+    | "INQUIRY"
+    | "CHECK_LIST";
   domainId: number;
   changedAt: string;
   changedBy: string;
@@ -51,7 +53,9 @@ export interface HistoryDetailResponse {
     | "PROJECT_STEP"
     | "POST"
     | "QUESTION"
-    | "CHAT";
+    | "CHAT"
+    | "INQUIRY"
+    | "CHECK_LIST";
   domainId: number;
   changedAt: string;
   changerId: string;

--- a/src/features/company/components/CompanyDetailModal/CompanyDetailModal.tsx
+++ b/src/features/company/components/CompanyDetailModal/CompanyDetailModal.tsx
@@ -80,7 +80,7 @@ const CompanyDetailModal: React.FC<CompanyDetailModalProps> = ({
           </DetailItem>
           <DetailItem>
             <DetailIcon>
-              <FiPhone size={14} />
+              <FiPhone size={14} style={{ color: "#10b981" }} />
             </DetailIcon>
             <DetailLabel>연락처:</DetailLabel>
             <DetailValue>{company.tel}</DetailValue>

--- a/src/features/company/components/CompanyEditModal/CompanyEditModal.tsx
+++ b/src/features/company/components/CompanyEditModal/CompanyEditModal.tsx
@@ -518,7 +518,7 @@ export default function CompanyEditModal({
           </FormGroup>
           <FormGroup>
             <Label>
-              <FiPhone size={14} />
+              <FiPhone size={14} style={{ color: "#10b981" }} />
               전화번호
             </Label>
             <Input

--- a/src/features/company/components/CompanyRegisterModal/CompanyRegisterModal.tsx
+++ b/src/features/company/components/CompanyRegisterModal/CompanyRegisterModal.tsx
@@ -492,7 +492,7 @@ export default function CompanyRegisterModal({
           </FormGroup>
           <FormGroup>
             <Label>
-              <FiPhone size={14} />
+              <FiPhone size={14} style={{ color: "#10b981" }} />
               전화번호
             </Label>
             <Input

--- a/src/features/company/pages/CompanyDetailPage.tsx
+++ b/src/features/company/pages/CompanyDetailPage.tsx
@@ -376,7 +376,7 @@ const CompanyDetailPage: React.FC = () => {
             </DetailItem>
             <DetailItem>
               <DetailIcon>
-                <FiPhone size={18} />
+                <FiPhone size={18} style={{ color: "#10b981" }} />
               </DetailIcon>
               <DetailLabel>연락처</DetailLabel>
               <DetailValue>{formatTelNo(company.tel)}</DetailValue>

--- a/src/features/company/pages/CompanyPage.tsx
+++ b/src/features/company/pages/CompanyPage.tsx
@@ -508,7 +508,7 @@ export default function CompanyPage() {
                         cursor: "pointer",
                       }}
                     >
-                      <FiHome size={14} style={{ color: "#f59e0b" }} />
+                      <FiHome size={14} style={{ color: "#8b5cf6" }} />
                       <span
                         style={{
                           fontSize: "14px",

--- a/src/features/company/pages/CompanyPage.tsx
+++ b/src/features/company/pages/CompanyPage.tsx
@@ -466,8 +466,10 @@ export default function CompanyPage() {
               <TableHeader>업체명</TableHeader>
               <TableHeader>사업자등록번호</TableHeader>
               <TableHeader>대표자</TableHeader>
-              <TableHeader>연락처</TableHeader>
-              <TableHeader>생성일</TableHeader>
+              <TableHeader style={{ padding: "8px 8px 8px 24px" }}>
+                연락처
+              </TableHeader>
+              <TableHeader style={{ padding: "8px 8px" }}>생성일</TableHeader>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -556,7 +558,7 @@ export default function CompanyPage() {
                       </span>
                     </div>
                   </TableCell>
-                  <TableCell>
+                  <TableCell style={{ padding: "8px 0px 8px 24px" }}>
                     <div
                       style={{
                         display: "flex",
@@ -571,7 +573,7 @@ export default function CompanyPage() {
                       </span>
                     </div>
                   </TableCell>
-                  <TableCell>
+                  <TableCell style={{ padding: "8px 8px" }}>
                     <div
                       style={{
                         display: "flex",

--- a/src/features/company/pages/CompanyPage.tsx
+++ b/src/features/company/pages/CompanyPage.tsx
@@ -565,7 +565,7 @@ export default function CompanyPage() {
                         cursor: "pointer",
                       }}
                     >
-                      <FiPhone size={14} style={{ color: "#f59e0b" }} />
+                      <FiPhone size={14} style={{ color: "#10b981" }} />
                       <span style={{ fontSize: "14px", color: "#374151" }}>
                         {formatTelNo(c.tel)}
                       </span>

--- a/src/features/user/pages/MemberDetailPage.tsx
+++ b/src/features/user/pages/MemberDetailPage.tsx
@@ -393,7 +393,7 @@ const MemberDetailPage: React.FC = () => {
             </DetailItem>
             <DetailItem>
               <DetailIcon>
-                <FiPhone size={18} />
+                <FiPhone size={18} style={{ color: "#10b981" }} />
               </DetailIcon>
               <DetailLabel>연락처</DetailLabel>
               <DetailValue>{formatTelNo(member.phone)}</DetailValue>

--- a/src/features/user/pages/MemberPage.tsx
+++ b/src/features/user/pages/MemberPage.tsx
@@ -862,7 +862,7 @@ export default function MemberPage() {
                       onClick={() => handleMemberClick(member)}
                     >
                       {member.position === "admin" ||
-                      member.position === "시스템관리자" ? (
+                      member.position === "시스템 관리자" ? (
                         <LuUserRoundCog
                           size={14}
                           style={{ color: "#8b5cf6" }}
@@ -873,7 +873,9 @@ export default function MemberPage() {
                           style={{ color: "#3b82f6" }}
                         />
                       ) : member.position === "developer" ||
-                        member.position === "개발자" ? (
+                        member.position === "개발자" ||
+                        member.position === "백엔드 개발자" ||
+                        member.position === "프론트엔드 개발자" ? (
                         <FiUser size={14} style={{ color: "#3b82f6" }} />
                       ) : member.position === "client" ||
                         member.position === "고객" ? (
@@ -887,10 +889,13 @@ export default function MemberPage() {
                       </span>
                       <span style={{ fontSize: "12px", color: "#6b7280" }}>
                         (
-                        {member.position === "admin"
+                        {member.position === "admin" ||
+                        member.position === "시스템 관리자"
                           ? "관리자"
                           : member.position === "developer" ||
-                            member.position === "개발자"
+                            member.position === "개발자" ||
+                            member.position === "백엔드 개발자" ||
+                            member.position === "프론트엔드 개발자"
                           ? "개발사 직원"
                           : member.position === "client" ||
                             member.position === "고객"
@@ -930,7 +935,7 @@ export default function MemberPage() {
                       onClick={() => handleMemberClick(member)}
                     >
                       {member.position === "admin" ||
-                      member.position === "시스템관리자" ? (
+                      member.position === "시스템 관리자" ? (
                         <LuUserRoundCog
                           size={14}
                           style={{ color: "#8b5cf6" }}
@@ -941,7 +946,9 @@ export default function MemberPage() {
                           style={{ color: "#3b82f6" }}
                         />
                       ) : member.position === "developer" ||
-                        member.position === "개발자" ? (
+                        member.position === "개발자" ||
+                        member.position === "백엔드 개발자" ||
+                        member.position === "프론트엔드 개발자" ? (
                         <FiUser size={14} style={{ color: "#3b82f6" }} />
                       ) : member.position === "client" ||
                         member.position === "고객" ? (

--- a/src/features/user/pages/MemberPage.tsx
+++ b/src/features/user/pages/MemberPage.tsx
@@ -18,7 +18,7 @@ import {
   FiCalendar,
 } from "react-icons/fi";
 import { IoBusinessOutline, IoPeopleOutline } from "react-icons/io5";
-import { LuUserRoundCog } from "react-icons/lu";
+import { LuUserRoundCog, LuUserRoundCheck } from "react-icons/lu";
 
 export interface Member {
   id: number;
@@ -861,10 +861,16 @@ export default function MemberPage() {
                       }}
                       onClick={() => handleMemberClick(member)}
                     >
-                      {member.position === "admin" ? (
+                      {member.position === "admin" ||
+                      member.position === "시스템관리자" ? (
                         <LuUserRoundCog
                           size={14}
                           style={{ color: "#8b5cf6" }}
+                        />
+                      ) : member.position === "팀장" ? (
+                        <LuUserRoundCheck
+                          size={14}
+                          style={{ color: "#3b82f6" }}
                         />
                       ) : member.position === "developer" ||
                         member.position === "개발자" ? (
@@ -923,10 +929,16 @@ export default function MemberPage() {
                       }}
                       onClick={() => handleMemberClick(member)}
                     >
-                      {member.position === "admin" ? (
+                      {member.position === "admin" ||
+                      member.position === "시스템관리자" ? (
                         <LuUserRoundCog
                           size={14}
                           style={{ color: "#8b5cf6" }}
+                        />
+                      ) : member.position === "팀장" ? (
+                        <LuUserRoundCheck
+                          size={14}
+                          style={{ color: "#3b82f6" }}
                         />
                       ) : member.position === "developer" ||
                         member.position === "개발자" ? (

--- a/src/features/user/pages/MemberPage.tsx
+++ b/src/features/user/pages/MemberPage.tsx
@@ -904,7 +904,7 @@ export default function MemberPage() {
                       }}
                       onClick={() => handleMemberClick(member)}
                     >
-                      <FiHome size={14} style={{ color: "#f59e0b" }} />
+                      <FiHome size={14} style={{ color: "#8b5cf6" }} />
                       <span style={{ fontWeight: "500" }}>
                         {(companies &&
                           companies.find((c) => c.id === member.companyId)


### PR DESCRIPTION
## 📌 개요
이력 상세 보기 UI 개선 및 복구 기능 추가, 이력 정보 가시성 및 표현 방식 개선

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [x] 스타일 수정 (Style)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- 이력 상세에서 수정/삭제 이력 복구 버튼 추가
- 이력 ID 복사 버튼 기능 추가
- 이력 ID, 작업 상세 메시지, 권한 텍스트 위치 조정
- ROLE_USER로 표시되던 변경자 권한 표기 오류 수정
- 이력 상세 UI 및 레이아웃 전반 개선
- 복구 버튼으로 인해 깨진 상세 UI 레이아웃 수정
- 회원 관련 이력에서 비밀번호 제거
- 이력 필터에 체크리스트, 문의 항목 추가
- 전화 색상 초록 계열 통일, 업체 색상 보라 계열로 통일
- 팀장 유저 아이콘 수정
- 업체 관리 항목 위치 조정

## 🔍 관련 이슈
- Close #147

## 🧪 테스트 결과
- UI 변경 후 이력 상세 정상 출력 확인
- 복구 버튼 클릭 시 복원 동작 정상 작동 확인
- 필터, 텍스트, 색상 스타일 정상 적용 확인

## 👀 리뷰어에게 요청사항
- 복구 버튼 및 권한 텍스트 로직 정상 작동 여부 확인 부탁드립니다

## 📎 기타 참고 사항
- 없음