### PR TITLE
[Feature] 게시글 복구 기능 개선 및 UI/UX 반영, 알림/토스트/모달 동기화, 복구 필터 연동 처리

### DIFF
--- a/src/features/admin/pages/ActivityLogPage.tsx
+++ b/src/features/admin/pages/ActivityLogPage.tsx
@@ -51,6 +51,7 @@ import {
   FiGrid,
   FiMessageSquare,
   FiCheckSquare,
+  FiRefreshCw,
 } from "react-icons/fi";
 import { FiPackage } from "react-icons/fi";
 import { LuUserRoundCog } from "react-icons/lu";
@@ -126,6 +127,7 @@ export default function ActivityLogPage() {
     { value: "CREATED", label: "생성", icon: FiPlusCircle, color: "#10b981" },
     { value: "UPDATED", label: "수정", icon: FiEdit, color: "#3b82f6" },
     { value: "DELETED", label: "삭제", icon: FiTrash, color: "#ef4444" },
+    { value: "RESTORED", label: "복구", icon: FiRefreshCw, color: "#8b5cf6" },
   ];
 
   const LOG_TYPE_OPTIONS = [
@@ -292,6 +294,15 @@ export default function ActivityLogPage() {
         return {
           backgroundColor: "#fee2e2",
           color: "#991b1b",
+          fontWeight: "600",
+          padding: "2px 8px",
+          borderRadius: "12px",
+          fontSize: "0.7rem",
+        };
+      case "RESTORED":
+        return {
+          backgroundColor: "#f3e8ff",
+          color: "#7c3aed",
           fontWeight: "600",
           padding: "2px 8px",
           borderRadius: "12px",
@@ -759,6 +770,7 @@ export default function ActivityLogPage() {
                     {log.action === "CREATED" && "생성"}
                     {log.action === "UPDATED" && "수정"}
                     {log.action === "DELETED" && "삭제"}
+                    {log.action === "RESTORED" && "복구"}
                   </StatusBadge>
                 </TableCell>
                 <TableCell style={{ width: "200px" }}>

--- a/src/features/admin/services/activityLogService.ts
+++ b/src/features/admin/services/activityLogService.ts
@@ -28,7 +28,7 @@ interface PageResponse<T> {
 
 interface HistorySimpleResponse {
   id: string;
-  historyType: "CREATED" | "UPDATED" | "DELETED";
+  historyType: "CREATED" | "UPDATED" | "DELETED" | "RESTORED";
   domainType:
     | "POST"
     | "USER"
@@ -130,6 +130,8 @@ export const transformHistoryToActivityLog = (
         return "수정";
       case "DELETED":
         return "삭제";
+      case "RESTORED":
+        return "복구";
       default:
         return historyType;
     }
@@ -258,12 +260,9 @@ export const getPostsDueSoon = async (): Promise<
     );
 
     // 백엔드 응답 구조 확인 - status가 "OK"인 경우 성공
-    if (
-      response.data.status === "OK" ||
-      response.data.status === "SUCCESS" 
-    ) {
+    if (response.data.status === "OK" || response.data.status === "SUCCESS") {
       // data 필드가 없으면 빈 배열 반환
-      return response.data.data ||  [];
+      return response.data.data || [];
     } else {
       throw new Error(response.data.message || "게시글 조회에 실패했습니다.");
     }
@@ -281,12 +280,9 @@ export const getMyMentions = async (): Promise<MyMentionListResponse[]> => {
     );
 
     // 백엔드 응답 구조 확인 - status가 "OK"인 경우 성공
-    if (
-      response.data.status === "OK" ||
-      response.data.status === "SUCCESS" 
-    ) {
+    if (response.data.status === "OK" || response.data.status === "SUCCESS") {
       // data 필드가 없으면 빈 배열 반환
-      return response.data.data ||  [];
+      return response.data.data || [];
     } else {
       throw new Error(response.data.message || "멘션 조회에 실패했습니다.");
     }
@@ -302,7 +298,6 @@ export const markNotificationAsRead = async (
 ): Promise<void> => {
   try {
     await api.put(`/api/notifications/read/${notificationId}`);
-
   } catch (error) {
     console.error("알림 읽음 처리 실패:", error);
     throw error;

--- a/src/features/admin/types/activityLog.ts
+++ b/src/features/admin/types/activityLog.ts
@@ -21,7 +21,7 @@ export interface PageResponse<T> {
 // 백엔드 이력 응답 타입
 export interface HistorySimpleResponse {
   id: string;
-  historyType: "CREATED" | "UPDATED" | "DELETED";
+  historyType: "CREATED" | "UPDATED" | "DELETED" | "RESTORED";
   domainType:
     | "USER"
     | "COMPANY"
@@ -45,7 +45,7 @@ export interface HistorySimpleResponse {
 // 백엔드 이력 상세 응답 타입
 export interface HistoryDetailResponse {
   id: string;
-  historyType: "CREATED" | "UPDATED" | "DELETED";
+  historyType: "CREATED" | "UPDATED" | "DELETED" | "RESTORED";
   domainType:
     | "USER"
     | "COMPANY"

--- a/src/features/board/components/Post/components/DetailModal/ProjectPostDetailModal.tsx
+++ b/src/features/board/components/Post/components/DetailModal/ProjectPostDetailModal.tsx
@@ -39,6 +39,7 @@ import PostLinks from "./PostLinks";
 import CommentSection from "./CommentSection";
 import { getUsersByProject } from "@/features/user/services/userService";
 import { extractCompletedMentions } from "@/utils/mentionUtils";
+import PostFormModal from "../FormModal/PostFormModal";
 
 interface PostDetailModalProps {
   open: boolean;
@@ -88,6 +89,9 @@ const PostDetailModal: React.FC<PostDetailModalProps> = ({
   } = useUserProfile();
 
   const [allUsernames, setAllUsernames] = useState<string[]>([]);
+
+  // 수정 모달 상태
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
   // 모달 닫기 애니메이션 적용
   const handleCloseWithAnimation = () => {
@@ -231,9 +235,30 @@ const PostDetailModal: React.FC<PostDetailModalProps> = ({
 
   // 게시글 수정 핸들러
   const handleEditPost = () => {
-    if (onEditPost && postId) {
-      onEditPost(postId);
+    if (postId) {
+      setIsEditModalOpen(true);
     }
+  };
+
+  // 수정 모달 닫기 핸들러
+  const handleEditModalClose = () => {
+    setIsEditModalOpen(false);
+  };
+
+  // 수정 완료 핸들러
+  const handleEditSuccess = async () => {
+    // 게시글 데이터 새로고침
+    if (postId) {
+      try {
+        const postResponse = await getPostDetail(postId);
+        if (postResponse.data) {
+          setPost(postResponse.data);
+        }
+      } catch (err) {
+        console.error("게시글 새로고침 실패:", err);
+      }
+    }
+    setIsEditModalOpen(false);
   };
 
   // 게시글 답글 핸들러
@@ -578,6 +603,18 @@ const PostDetailModal: React.FC<PostDetailModalProps> = ({
           isAdmin={profileState.isAdmin}
         />
       )}
+
+      {/* 게시글 수정 모달 */}
+      <PostFormModal
+        open={isEditModalOpen}
+        onClose={handleEditModalClose}
+        mode="edit"
+        postId={postId || undefined}
+        projectId={post?.project?.projectId || 1}
+        stepId={post?.projectStepId || 1}
+        onSuccess={handleEditSuccess}
+        colorTheme={{ main: "#fdb924", sub: "#f59e0b" }}
+      />
     </>
   );
 };

--- a/src/features/board/components/Post/components/FormModal/PostFormModal.tsx
+++ b/src/features/board/components/Post/components/FormModal/PostFormModal.tsx
@@ -47,7 +47,6 @@ import {
   FiAlertTriangle,
   FiTarget,
   FiPlus,
-  FiFileText,
 } from "react-icons/fi";
 import FullScreenContentEditor from "./FullScreenContentEditor";
 import FileUploadSection from "./components/FileUploadSection";
@@ -178,7 +177,7 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
           if (post) {
             // 기존 게시글의 stepId를 우선적으로 사용
             // (기존 게시글이 속한 단계가 기본으로 선택되도록)
-            const currentStepId = post.stepId || stepId;
+            const currentStepId = post.projectStepId || stepId;
 
             setFormData({
               projectId: projectId,
@@ -274,7 +273,10 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
     const { name, value } = e.target;
     setFormData((prev) => ({
       ...prev,
-      [name]: name === "priority" ? (Number(value) as PostPriority) : value,
+      [name]:
+        name === "priority"
+          ? (Number(value) as unknown as PostPriority)
+          : value,
     }));
     setFormErrors((prev) => ({ ...prev, [name]: "" }));
   };
@@ -403,7 +405,7 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
 
         // 수정 전 기존 게시글 정보 저장 (단계 변경 확인용)
         const originalPost = await getPostDetail(postId);
-        const originalStepId = originalPost.data?.stepId;
+        const originalStepId = originalPost.data?.projectStepId;
 
         const response = await updatePost(postId, requestData, files);
         if (response.success || response.message?.includes("완료")) {
@@ -441,7 +443,7 @@ const PostFormModal: React.FC<PostFormModalProps> = ({
           throw new Error(response.message || "게시글 수정에 실패했습니다.");
         }
       }
-    }, null); // 에러 메시지를 null로 설정하여 withErrorHandling에서 토스트를 표시하지 않음
+    }, undefined); // 에러 메시지를 undefined로 설정하여 withErrorHandling에서 토스트를 표시하지 않음
 
     // withErrorHandling에서 null이 반환되면 에러가 발생한 것이므로 직접 에러 토스트 표시
     if (result === null) {

--- a/src/features/board/components/Post/components/FormModal/components/FileUploadSection.tsx
+++ b/src/features/board/components/Post/components/FormModal/components/FileUploadSection.tsx
@@ -24,7 +24,7 @@ interface FileUploadSectionProps {
   files: File[];
   existingFiles: PostFile[];
   isDragOver: boolean;
-  fileInputRef: React.RefObject<HTMLInputElement>;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
   handleFileDrop: (e: React.DragEvent) => void;
   handleDragOver: (e: React.DragEvent) => void;
   handleDragLeave: (e: React.DragEvent) => void;

--- a/src/features/project-d/services/postService.ts
+++ b/src/features/project-d/services/postService.ts
@@ -114,7 +114,6 @@ export const createPost = async (
 
     return handleApiResponse<PostCreateResponse>(response);
   } catch (error) {
-
     if (error instanceof ApiError) throw error;
     if (error instanceof AxiosError) {
       console.error(

--- a/src/features/project-d/services/postService.ts
+++ b/src/features/project-d/services/postService.ts
@@ -53,6 +53,7 @@ const handleApiResponse = async <T>(
     "COMMENT_CREATE_SUCCESS",
     "COMMENT_UPDATE_SUCCESS",
     "COMMENT_DELETE_SUCCESS",
+    "비활성화 게시글 복구 완료",
   ];
 
   // success가 false이고, 메시지가 성공 메시지가 아닌 경우에만 에러로 처리

--- a/src/features/project-d/services/postService.ts
+++ b/src/features/project-d/services/postService.ts
@@ -546,3 +546,24 @@ export const searchPosts = async (
     throw new ApiError("게시글 검색 중 알 수 없는 오류가 발생했습니다.");
   }
 };
+
+// 게시글 복구
+export const restorePost = async (
+  postId: number
+): Promise<ApiResponse<any>> => {
+  try {
+    const response = await api.put<ApiResponse<any>>(
+      `/api/posts/${postId}/restore`
+    );
+    return handleApiResponse<any>(response);
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
+    if (error instanceof AxiosError) {
+      throw new ApiError(
+        error.response?.data?.message || "게시글 복구 중 오류가 발생했습니다.",
+        error.response?.status
+      );
+    }
+    throw new ApiError("게시글 복구 중 알 수 없는 오류가 발생했습니다.");
+  }
+};

--- a/src/features/project/services/projectService.ts
+++ b/src/features/project/services/projectService.ts
@@ -74,7 +74,7 @@ export type ProjectDetailResponse = {
   endDate: string;
   projectCost: string;
   projectStatus: string;
-  progress : number;
+  progress: number;
   clients: ProjectCompany[];
   developers: ProjectCompany[];
   steps: ProjectDetailStep[];
@@ -88,8 +88,8 @@ export type ProjectStatusResponse = {
   description: string;
   startDate: string;
   endDate: string;
-  progress : number;
-  status : string;
+  progress: number;
+  status: string;
 };
 
 // 프로젝트 상세 조회 응답 타입
@@ -116,7 +116,7 @@ export type ProjectResponse = {
   startDate: string;
   endDate: string;
   projectStatus: string;
-  progress : number;
+  progress: number;
   assignClientCompanies: CompanySummaryResponse[];
   assignDevCompanies: CompanySummaryResponse[];
 };
@@ -165,16 +165,21 @@ export const getProjects = async (
     keyword?: string;
     sort?: string;
   } = {}
-): Promise<ApiResponse<{ content: ProjectResponse[]; page: PageMetadata; }>> => {
+): Promise<ApiResponse<{ content: ProjectResponse[]; page: PageMetadata }>> => {
   try {
-    const response = await api.get<ApiResponse<{ content: ProjectResponse[]; page: PageMetadata; }>>("/api/projects", {
+    const response = await api.get<
+      ApiResponse<{ content: ProjectResponse[]; page: PageMetadata }>
+    >("/api/projects", {
       params: {
         page,
         size,
         ...params,
       },
     });
-    return handleApiResponse<{ content: ProjectResponse[]; page: PageMetadata; }>(response);
+    return handleApiResponse<{
+      content: ProjectResponse[];
+      page: PageMetadata;
+    }>(response);
   } catch (error) {
     if (error instanceof ApiError) throw error;
     if (error instanceof AxiosError) {
@@ -215,16 +220,21 @@ export const searchProjects = async (
   keyword: string,
   page: number = 0,
   size: number = 10
-): Promise<ApiResponse<{ content: ProjectResponse[]; page: PageMetadata; }>> => {
+): Promise<ApiResponse<{ content: ProjectResponse[]; page: PageMetadata }>> => {
   try {
-    const response = await api.get<ApiResponse<{ content: ProjectResponse[]; page: PageMetadata; }>>("/api/projects/search", {
+    const response = await api.get<
+      ApiResponse<{ content: ProjectResponse[]; page: PageMetadata }>
+    >("/api/projects/search", {
       params: {
         keyword,
         page,
         size,
       },
     });
-    return handleApiResponse<{ content: ProjectResponse[]; page: PageMetadata; }>(response);
+    return handleApiResponse<{
+      content: ProjectResponse[];
+      page: PageMetadata;
+    }>(response);
   } catch (error) {
     if (error instanceof ApiError) throw error;
     if (error instanceof AxiosError) {
@@ -243,9 +253,12 @@ export const getProjectStatusByStatus = async (
   status: string
 ): Promise<ApiResponse<ProjectStatusResponse[]>> => {
   try {
-    const response = await api.get<ApiResponse<ProjectStatusResponse[]>>(`/api/projects/status`, {
-      params: { status },
-    });
+    const response = await api.get<ApiResponse<ProjectStatusResponse[]>>(
+      `/api/projects/status`,
+      {
+        params: { status },
+      }
+    );
     return handleApiResponse<ProjectStatusResponse[]>(response);
   } catch (error) {
     if (error instanceof ApiError) throw error;
@@ -256,6 +269,30 @@ export const getProjectStatusByStatus = async (
         error.response?.status
       );
     }
-    throw new ApiError("프로젝트 상태별 현황 조회 중 알 수 없는 오류가 발생했습니다.");
+    throw new ApiError(
+      "프로젝트 상태별 현황 조회 중 알 수 없는 오류가 발생했습니다."
+    );
+  }
+};
+
+// 프로젝트 복구
+export const restoreProject = async (
+  projectId: number
+): Promise<ApiResponse<any>> => {
+  try {
+    const response = await api.put<ApiResponse<any>>(
+      `/api/projects/${projectId}/restore`
+    );
+    return handleApiResponse<any>(response);
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
+    if (error instanceof AxiosError) {
+      throw new ApiError(
+        error.response?.data?.message ||
+          "프로젝트 복구 중 오류가 발생했습니다.",
+        error.response?.status
+      );
+    }
+    throw new ApiError("프로젝트 복구 중 알 수 없는 오류가 발생했습니다.");
   }
 };

--- a/src/features/user/pages/dashboard/components/MentionedPostsSection.tsx
+++ b/src/features/user/pages/dashboard/components/MentionedPostsSection.tsx
@@ -187,7 +187,6 @@ const MentionedPostsSection = () => {
       const data = await getMyMentions();
       setMentions(data);
     } catch (err) {
-      console.error("알림 조회 실패:", err);
       setError("알림을 불러오는데 실패했습니다.");
     } finally {
       setLoading(false);
@@ -195,8 +194,6 @@ const MentionedPostsSection = () => {
   };
 
   const handleMentionClick = async (mention: MyMentionListResponse) => {
-    console.log("알림 클릭:", mention);
-
     // 읽지 않은 알림인 경우 읽음 처리
     if (!mention.isRead) {
       try {
@@ -210,7 +207,6 @@ const MentionedPostsSection = () => {
           )
         );
       } catch (error) {
-        console.error("알림 읽음 처리 실패:", error);
         // 읽음 처리 실패해도 계속 진행
       }
     }
@@ -219,61 +215,55 @@ const MentionedPostsSection = () => {
     switch (mention.type) {
       case "MENTIONED":
         // 멘션된 게시글로 이동
-        console.log("멘션된 게시글로 이동:", mention.postId);
         if (mention.postId) {
           setSelectedPostId(mention.postId);
           setIsDetailModalOpen(true);
-        } else {
-          console.error("postId가 없어서 게시글 상세로 이동할 수 없습니다.");
         }
         break;
 
       case "COMMENT_POST_CREATED":
         // 내 게시글에 댓글이 달린 경우
-        console.log("내 게시글에 댓글이 달린 경우:", mention.postId);
         if (mention.postId) {
           setSelectedPostId(mention.postId);
           setIsDetailModalOpen(true);
-        } else {
-          console.error("postId가 없어서 게시글 상세로 이동할 수 없습니다.");
         }
         break;
 
       case "COMMENT_REPLY_CREATED":
         // 내 댓글에 대댓글이 달린 경우 - 해당 게시글 상세로 이동
-        console.log("댓글이 달린 게시글 상세로 이동:", mention.postId);
         if (mention.postId) {
           setSelectedPostId(mention.postId);
           setIsDetailModalOpen(true);
-        } else {
-          console.error("postId가 없어서 게시글 상세로 이동할 수 없습니다.");
         }
         break;
 
       case "POST_REPLY_CREATED":
         // 내 게시글에 답글이 달린 경우 - 해당 게시글 상세로 이동
-        console.log("내 게시글에 답글이 달린 경우:", mention.postId);
         if (mention.postId) {
           setSelectedPostId(mention.postId);
           setIsDetailModalOpen(true);
-        } else {
-          console.error("postId가 없어서 게시글 상세로 이동할 수 없습니다.");
         }
         break;
 
       case "PROJECT_POST_CREATED":
         // 프로젝트에 새로운 게시글이 등록된 경우 - 게시글 상세로 이동
-        console.log("새 게시글 상세로 이동:", mention.postId);
         if (mention.postId) {
           setSelectedPostId(mention.postId);
           setIsDetailModalOpen(true);
-        } else {
-          console.error("postId가 없어서 게시글 상세로 이동할 수 없습니다.");
+        }
+        break;
+
+      case "POST_RESTORED":
+        // 게시글이 복구된 경우 - 해당 게시글 상세로 이동
+        if (mention.postId) {
+          setSelectedPostId(mention.postId);
+          setIsDetailModalOpen(true);
         }
         break;
 
       default:
-        console.log("알 수 없는 알림 타입:", mention.type);
+        // 알 수 없는 알림 타입은 무시
+        break;
     }
   };
 

--- a/src/features/user/pages/dashboard/components/MentionedPostsSection.tsx
+++ b/src/features/user/pages/dashboard/components/MentionedPostsSection.tsx
@@ -1,7 +1,15 @@
 import React, { useState, useEffect } from "react";
 import * as S from "../styled/UserDashboardPage.styled";
 import { MdAccessTime, MdComment, MdReply, MdPostAdd } from "react-icons/md";
-import { FiRotateCcw, FiAtSign, FiBell } from "react-icons/fi";
+import {
+  FiRotateCcw,
+  FiAtSign,
+  FiBell,
+  FiCheckSquare,
+  FiCheck,
+  FiX,
+  FiPackage,
+} from "react-icons/fi";
 import {
   getMyMentions,
   markNotificationAsRead,
@@ -130,6 +138,16 @@ const MentionedPostsSection = () => {
         return <MdReply size={14} style={{ color: "#f59e0b" }} />;
       case "PROJECT_POST_CREATED":
         return <MdPostAdd size={14} style={{ color: "#8b5cf6" }} />;
+      case "POST_RESTORED":
+        return <FiRotateCcw size={14} style={{ color: "#8b5cf6" }} />;
+      case "STEP_APPROVAL_REQUEST":
+        return <FiCheckSquare size={14} style={{ color: "#f59e0b" }} />;
+      case "STEP_APPROVAL_ACCEPTED":
+        return <FiCheck size={14} style={{ color: "#10b981" }} />;
+      case "STEP_APPROVAL_REJECTED":
+        return <FiX size={14} style={{ color: "#ef4444" }} />;
+      case "PROJECT_CREATE_ASSIGNMENT":
+        return <FiPackage size={14} style={{ color: "#3b82f6" }} />;
       default:
         return <FiAtSign size={14} style={{ color: "#6b7280" }} />;
     }
@@ -147,6 +165,16 @@ const MentionedPostsSection = () => {
         return "답글 알림";
       case "PROJECT_POST_CREATED":
         return "새 게시글";
+      case "POST_RESTORED":
+        return "게시글 복구";
+      case "STEP_APPROVAL_REQUEST":
+        return "단계 승인 요청";
+      case "STEP_APPROVAL_ACCEPTED":
+        return "단계 승인 완료";
+      case "STEP_APPROVAL_REJECTED":
+        return "단계 승인 거절";
+      case "PROJECT_CREATE_ASSIGNMENT":
+        return "프로젝트 배정";
       default:
         return "알림";
     }

--- a/src/layouts/Header/notification/NotificationDropdown.tsx
+++ b/src/layouts/Header/notification/NotificationDropdown.tsx
@@ -33,7 +33,7 @@ const NotificationDropdown: React.FC<Props> = ({
   markAsRead,
   error,
   onDelete,
-  onMarkAllAsRead
+  onMarkAllAsRead,
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -44,7 +44,10 @@ const NotificationDropdown: React.FC<Props> = ({
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
         setIsOpen(false);
       }
     };
@@ -57,7 +60,10 @@ const NotificationDropdown: React.FC<Props> = ({
 
   const handleNotificationClick = (notification: SseNotification) => {
     console.log(notification);
-    if (notification.type === "PROJECT_CREATE_ASSIGNMENT" && notification.projectId) {
+    if (
+      notification.type === "PROJECT_CREATE_ASSIGNMENT" &&
+      notification.projectId
+    ) {
       navigate(`/projects/${notification.projectId}/detail`);
       setIsOpen(false);
     } else if (
@@ -65,12 +71,31 @@ const NotificationDropdown: React.FC<Props> = ({
         "PROJECT_POST_CREATED",
         "POST_REPLY_CREATED",
         "COMMENT_POST_CREATED",
-        "COMMENT_REPLY_CREATED"
-      ].includes(notification.type) && notification.postId
+        "COMMENT_REPLY_CREATED",
+        "POST_RESTORED",
+      ].includes(notification.type) &&
+      notification.postId
     ) {
       navigate(`/projects/${notification.projectId}/detail`);
       setModalPostId(notification.postId);
       setIsOpen(false);
+    } else if (notification.type === "MENTIONED") {
+      // 멘션 알림 처리
+      if (notification.postId) {
+        navigate(`/projects/${notification.projectId}/detail`);
+        setModalPostId(notification.postId);
+        setIsOpen(false);
+      }
+    } else if (
+      notification.type === "STEP_APPROVAL_REQUEST" ||
+      notification.type === "STEP_APPROVAL_ACCEPTED" ||
+      notification.type === "STEP_APPROVAL_REJECTED"
+    ) {
+      // 단계 승인 관련 알림 처리
+      if (notification.projectId) {
+        navigate(`/projects/${notification.projectId}/detail`);
+        setIsOpen(false);
+      }
     }
     markAsRead(notification.id);
   };
@@ -89,15 +114,19 @@ const NotificationDropdown: React.FC<Props> = ({
         key={n.id}
         $isRead={n.isRead}
         onClick={() => handleNotificationClick(n)}
-        style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
       >
         <NotificationMessage>{n.message}</NotificationMessage>
         <NotificationTime>{n.time}</NotificationTime>
         {onDelete && (
           <button
-            onClick={e => {
+            onClick={(e) => {
               e.stopPropagation();
-              if (window.confirm('정말 삭제할까요?')) {
+              if (window.confirm("정말 삭제할까요?")) {
                 onDelete(n.id);
               }
             }}
@@ -106,7 +135,7 @@ const NotificationDropdown: React.FC<Props> = ({
               border: "none",
               cursor: "pointer",
               marginLeft: "8px",
-              color: "#888"
+              color: "#888",
             }}
             title="알림 삭제"
           >
@@ -136,9 +165,7 @@ const NotificationDropdown: React.FC<Props> = ({
                 </MarkAllAsReadButton>
               )}
             </NotificationHeader>
-            <NotificationList>
-              {renderContent()}
-            </NotificationList>
+            <NotificationList>{renderContent()}</NotificationList>
           </DropdownMenu>
         )}
       </DropdownContainer>

--- a/src/layouts/Header/notification/NotificationDropdown.tsx
+++ b/src/layouts/Header/notification/NotificationDropdown.tsx
@@ -59,7 +59,6 @@ const NotificationDropdown: React.FC<Props> = ({
   const unreadCount = notifications.filter((n) => !n.isRead).length;
 
   const handleNotificationClick = (notification: SseNotification) => {
-    console.log(notification);
     if (
       notification.type === "PROJECT_CREATE_ASSIGNMENT" &&
       notification.projectId


### PR DESCRIPTION
## 📌 개요  
게시글 복구 기능 개선 및 UI/UX 반영, 알림/토스트/모달 동기화, 복구 필터 연동 처리

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- 삭제된 게시글 복구 기능 추가 (#204)
- 복구된 게시글에 토스트 알림 및 복구 버튼 상태 반영 (#204)
- 복구된 게시글도 알림 목록에 포함되도록 수정 (#204)
- 에러 발생 시 토스트와 상세 모달에 중복 출력되지 않도록 개선 (#204)
- 게시글 수정 후 즉시 화면에 반영되도록 동기화 로직 수정
- 이력관리 화면에서 복구된 게시글에 복구 뱃지 및 아이콘 추가
- 이력관리 검색 필터에 복구 상태 연동

## 🔍 관련 이슈
- Close #204

## 🧪 테스트 결과


## 👀 리뷰어에게 요청사항

## 📎 기타 참고 사항
